### PR TITLE
Update GitHub App URL in README and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A secure token broker service that manages GitHub App tokens, providing both ins
 
 To use the As-A-Bot GitHub App in your repositories:
 
-1. **Install the GitHub App**: Visit https://github.com/apps/as-a-bot-app
+1. **Install the GitHub App**: Visit https://github.com/apps/as-a-bot
 2. **Select repositories**: Choose which repositories the app should have access to
 3. **Configure permissions**: Grant the necessary permissions for your use case
 4. **Start using the API**: Once installed, you can request tokens for your repositories using the API endpoints

--- a/check-app-installation.sh
+++ b/check-app-installation.sh
@@ -7,7 +7,7 @@
 set -e
 
 # Configuration
-APP_NAME="as-a-bot-app"
+APP_NAME="as-a-bot"
 APP_URL="https://github.com/apps/${APP_NAME}"
 BROKER_URL="https://as-bot-worker.minivelos.workers.dev"
 


### PR DESCRIPTION
## Summary
- Updated the GitHub App URL from `as-a-bot-app` to `as-a-bot` in both the README and the installation check script.

## Changes

### Documentation
- **README.md**: Corrected the GitHub App installation URL to https://github.com/apps/as-a-bot to reflect the accurate app name.

### Scripts
- **check-app-installation.sh**: Updated the `APP_NAME` variable to `as-a-bot` to match the new GitHub App URL.

## Test plan
- Verified that the updated URL in the README directs to the correct GitHub App page.
- Confirmed that the script uses the correct app name and URL for installation checks.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c806e910-579e-420f-be55-cc40b86ee1a0