### PR TITLE
Add image upload brokering for `gh image`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,10 @@
 #   CLOUDFLARE_TOKEN       API token with Workers Scripts edit permission
 #   R2_ACCESS_KEY_ID       R2 S3 credential (pre-signing upload URLs)
 #   R2_SECRET_ACCESS_KEY   R2 S3 credential
-#   GITHUB_WEBHOOK_SECRET  App webhook secret (must match the GitHub App settings)
+#   GH_WEBHOOK_SECRET      App webhook secret (must match the GitHub App
+#                          settings; Actions secret names may not start with
+#                          GITHUB_, so it syncs to the worker secret
+#                          GITHUB_WEBHOOK_SECRET)
 #
 # Worker secrets are synced before each deploy, so rotating one is just
 # updating the Actions secret and re-running this workflow.
@@ -43,18 +46,21 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          GITHUB_WEBHOOK_SECRET: ${{ secrets.GITHUB_WEBHOOK_SECRET }}
+          WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
-          for name in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY GITHUB_WEBHOOK_SECRET; do
-            value="${!name}"
+          sync() {
+            local name="$1" value="$2"
             if [ -n "$value" ]; then
               printf '%s' "$value" | npx wrangler secret put "$name"
               echo "Synced secret: $name"
             else
               echo "Skipping unset secret: $name"
             fi
-          done
+          }
+          sync R2_ACCESS_KEY_ID "$R2_ACCESS_KEY_ID"
+          sync R2_SECRET_ACCESS_KEY "$R2_SECRET_ACCESS_KEY"
+          sync GITHUB_WEBHOOK_SECRET "$WEBHOOK_SECRET"
 
       - name: Deploy
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+# Deploy the worker on every push to main.
+#
+# Required Actions secrets:
+#   CLOUDFLARE_TOKEN       API token with Workers Scripts edit permission
+#   R2_ACCESS_KEY_ID       R2 S3 credential (pre-signing upload URLs)
+#   R2_SECRET_ACCESS_KEY   R2 S3 credential
+#   GITHUB_WEBHOOK_SECRET  App webhook secret (must match the GitHub App settings)
+#
+# Worker secrets are synced before each deploy, so rotating one is just
+# updating the Actions secret and re-running this workflow.
+
+name: Deploy Worker
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Sync worker secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          GITHUB_WEBHOOK_SECRET: ${{ secrets.GITHUB_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          for name in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY GITHUB_WEBHOOK_SECRET; do
+            value="${!name}"
+            if [ -n "$value" ]; then
+              printf '%s' "$value" | npx wrangler secret put "$name"
+              echo "Synced secret: $name"
+            else
+              echo "Skipping unset secret: $name"
+            fi
+          done
+
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+        run: npx wrangler deploy

--- a/README.md
+++ b/README.md
@@ -149,18 +149,27 @@ The workflow is committed automatically; no secrets or variables are needed.
 
 ### Worker setup
 
+Deployment is CI-driven: every push to `main` runs the tests, syncs worker
+secrets, and deploys (`.github/workflows/deploy.yml`). Set these **Actions
+secrets** on this repo once:
+
+| Actions secret | Purpose |
+|----------------|---------|
+| `CLOUDFLARE_TOKEN` | API token with Workers Scripts edit (deploy) |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 credential (pre-signing only) |
+| `GITHUB_WEBHOOK_SECRET` | App webhook secret — same value as in the app settings |
+
+One-time infrastructure (already provisioned for the canonical deployment):
+
 ```bash
 wrangler r2 bucket create as-a-bot-images
 wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-days 90
-wrangler secret put R2_ACCESS_KEY_ID       # R2 S3 credential (pre-signing only)
-wrangler secret put R2_SECRET_ACCESS_KEY
-wrangler secret put GITHUB_WEBHOOK_SECRET  # app webhook secret for /webhook
-wrangler deploy
 ```
 
-The GitHub App needs its webhook pointed at `/webhook`, the **Installation**
-event subscription, and **Contents + Workflows (Read & write)** repository
-permissions for the auto-install.
+The GitHub App needs its webhook pointed at `/webhook` (with
+`GITHUB_WEBHOOK_SECRET`) and **Contents + Workflows (Read & write)**
+repository permissions for the auto-install. Installation events are
+delivered to GitHub Apps automatically.
 
 ## ⚙️ Configuration
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,13 @@ curl -X POST https://api.github.com/repos/OWNER/REPO/issues \
 `gh` cannot attach images to PRs or issues ([cli/cli#12960](https://github.com/cli/cli/issues/12960)),
 which is a real limitation for coding agents. This worker doubles as an upload
 broker for the `gh image` command in
-[ai-aligned-gh](https://github.com/ai-ecoverse/ai-aligned-gh): a GitHub Actions
-workflow in the target repo (dispatchable only by users with write access)
-pre-signs a checksum-bound R2 PUT URL and registers it here; `gh image` polls
-for it, uploads the file, and gets back a stable serve URL.
+[ai-aligned-gh](https://github.com/ai-ecoverse/ai-aligned-gh): a secret-free
+GitHub Actions workflow in the target repo (dispatchable only by users with
+write access, and **committed automatically when the app is installed**)
+proves repository identity via OIDC; the worker mints a checksum-bound
+pre-signed R2 PUT URL; `gh image` polls for it, uploads the file, and gets
+back a stable serve URL. Uploads are kept for 90 days — re-running
+`gh image` on the same file renews the same URL.
 
 See **[docs/image-upload-design.md](docs/image-upload-design.md)** for the full
 design and trust model.
@@ -133,24 +136,31 @@ design and trust model.
 ### Endpoints
 
 ```bash
-POST /image-upload/offer     # workflow registers a pre-signed URL (GitHub OIDC auth)
+POST /webhook                # app installation events: auto-install the workflow
+POST /image-upload/offer     # workflow requests a pre-signed URL (GitHub OIDC auth)
 GET  /image-upload/status    # gh image polls: ?owner=&repo=&hash=&ext=
-GET  /i/{owner}/{repo}/{hash}.{ext}   # serve the uploaded file (immutable)
+GET  /i/{owner}/{repo}/{hash}.{ext}   # serve the uploaded file (immutable, 90-day TTL)
 ```
 
 ### Repo setup
 
-1. Copy [`templates/image-upload.yml`](templates/image-upload.yml) to
-   `.github/workflows/image-upload.yml` in your repository.
-2. Add Actions secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
-   `R2_SECRET_ACCESS_KEY` (an R2 API token with object write on the bucket).
+Install the [as-a-bot app](https://github.com/apps/as-a-bot) on the repository.
+The workflow is committed automatically; no secrets or variables are needed.
 
 ### Worker setup
 
 ```bash
 wrangler r2 bucket create as-a-bot-images
+wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-days 90
+wrangler secret put R2_ACCESS_KEY_ID       # R2 S3 credential (pre-signing only)
+wrangler secret put R2_SECRET_ACCESS_KEY
+wrangler secret put GITHUB_WEBHOOK_SECRET  # app webhook secret for /webhook
 wrangler deploy
 ```
+
+The GitHub App needs its webhook pointed at `/webhook`, the **Installation**
+event subscription, and **Contents + Workflows (Read & write)** repository
+permissions for the auto-install.
 
 ## ⚙️ Configuration
 
@@ -159,6 +169,9 @@ wrangler deploy
 | `GITHUB_CLIENT_ID` | GitHub App Client ID | Yes |
 | `GITHUB_API` | GitHub API URL (default: https://api.github.com) | No |
 | `IMAGE_OIDC_AUDIENCE` | OIDC audience for image upload offers (default: as-a-bot-images) | No |
+| `R2_ACCOUNT_ID` / `R2_BUCKET` | R2 coordinates for image uploads | For gh image |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 credentials (secret; pre-signing only) | For gh image |
+| `GITHUB_WEBHOOK_SECRET` | App webhook secret (secret; for /webhook) | For auto-install |
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,48 @@ curl -X POST https://api.github.com/repos/OWNER/REPO/issues \
 
 **Expected**: Issue shows your username + app badge, NOT "app/as-a-bot"
 
+## 🖼️ Image Uploads (`gh image`)
+
+`gh` cannot attach images to PRs or issues ([cli/cli#12960](https://github.com/cli/cli/issues/12960)),
+which is a real limitation for coding agents. This worker doubles as an upload
+broker for the `gh image` command in
+[ai-aligned-gh](https://github.com/ai-ecoverse/ai-aligned-gh): a GitHub Actions
+workflow in the target repo (dispatchable only by users with write access)
+pre-signs a checksum-bound R2 PUT URL and registers it here; `gh image` polls
+for it, uploads the file, and gets back a stable serve URL.
+
+See **[docs/image-upload-design.md](docs/image-upload-design.md)** for the full
+design and trust model.
+
+### Endpoints
+
+```bash
+POST /image-upload/offer     # workflow registers a pre-signed URL (GitHub OIDC auth)
+GET  /image-upload/status    # gh image polls: ?owner=&repo=&hash=&ext=
+GET  /i/{owner}/{repo}/{hash}.{ext}   # serve the uploaded file (immutable)
+```
+
+### Repo setup
+
+1. Copy [`templates/image-upload.yml`](templates/image-upload.yml) to
+   `.github/workflows/image-upload.yml` in your repository.
+2. Add Actions secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
+   `R2_SECRET_ACCESS_KEY` (an R2 API token with object write on the bucket).
+
+### Worker setup
+
+```bash
+wrangler r2 bucket create as-a-bot-images
+wrangler deploy
+```
+
 ## ⚙️ Configuration
 
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `GITHUB_CLIENT_ID` | GitHub App Client ID | Yes |
 | `GITHUB_API` | GitHub API URL (default: https://api.github.com) | No |
+| `IMAGE_OIDC_AUDIENCE` | OIDC audience for image upload offers (default: as-a-bot-images) | No |
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ secrets** on this repo once:
 |----------------|---------|
 | `CLOUDFLARE_TOKEN` | API token with Workers Scripts edit (deploy) |
 | `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 credential (pre-signing only) |
-| `GITHUB_WEBHOOK_SECRET` | App webhook secret — same value as in the app settings |
+| `GH_WEBHOOK_SECRET` | App webhook secret — same value as in the app settings (synced to the `GITHUB_WEBHOOK_SECRET` worker secret; Actions secret names may not start with `GITHUB_`) |
 
 One-time infrastructure (already provisioned for the canonical deployment):
 

--- a/app-install.js
+++ b/app-install.js
@@ -1,0 +1,187 @@
+/**
+ * GitHub App installation webhook: when as-a-bot is installed on a
+ * repository (or added to more repositories), commit the image-upload
+ * workflow to each repo automatically so `gh image` works with zero
+ * per-repo setup — no secrets, no manual workflow copying.
+ *
+ * Requirements on the GitHub App:
+ *  - Webhook URL pointing at POST /webhook with GITHUB_WEBHOOK_SECRET set
+ *  - Subscribed to "Installation" events
+ *  - Repository permissions: Contents (read & write), Workflows (read & write)
+ */
+
+import { signJWT } from './jwt-simple.js';
+import { IMAGE_UPLOAD_WORKFLOW_PATH, IMAGE_UPLOAD_WORKFLOW_YAML } from './workflow-template.js';
+
+const encoder = new TextEncoder();
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+function bufferToHex(buffer) {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// btoa only accepts Latin-1; encode UTF-8 text (the workflow YAML contains
+// non-ASCII characters) via its bytes.
+function base64EncodeUtf8(text) {
+  const bytes = encoder.encode(text);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+async function verifyWebhookSignature(secret, rawBody, signatureHeader) {
+  if (!signatureHeader || !signatureHeader.startsWith('sha256=')) {
+    return false;
+  }
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  return timingSafeEqual(`sha256=${bufferToHex(mac)}`, signatureHeader);
+}
+
+async function createAppJWT(appId, privateKey) {
+  const now = Math.floor(Date.now() / 1000);
+  return signJWT({ iat: now - 60, exp: now + 600, iss: appId }, privateKey);
+}
+
+function githubHeaders(token) {
+  return {
+    'Authorization': `Bearer ${token}`,
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': 'as-a-bot-worker'
+  };
+}
+
+async function createInstallationToken(env, installationId) {
+  const jwt = await createAppJWT(env.GITHUB_APP_ID, env.GITHUB_APP_PRIVATE_KEY);
+  const apiBase = env.GITHUB_API || 'https://api.github.com';
+  const response = await fetch(`${apiBase}/app/installations/${installationId}/access_tokens`, {
+    method: 'POST',
+    headers: githubHeaders(jwt)
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create installation token (status ${response.status})`);
+  }
+  const data = await response.json();
+  return data.token;
+}
+
+/**
+ * Commit the image-upload workflow to a repository unless it already has
+ * one. Returns 'installed', 'exists', or 'error'.
+ */
+export async function installWorkflowInRepo(env, token, fullName) {
+  const apiBase = env.GITHUB_API || 'https://api.github.com';
+  const contentsUrl = `${apiBase}/repos/${fullName}/contents/${IMAGE_UPLOAD_WORKFLOW_PATH}`;
+
+  try {
+    const existing = await fetch(contentsUrl, { headers: githubHeaders(token) });
+    if (existing.status === 200) {
+      return 'exists';
+    }
+    if (existing.status !== 404) {
+      throw new Error(`Unexpected status checking for existing workflow: ${existing.status}`);
+    }
+
+    const put = await fetch(contentsUrl, {
+      method: 'PUT',
+      headers: { ...githubHeaders(token), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: 'Add image-upload workflow for gh image\n\nInstalled automatically by the as-a-bot app.',
+        content: base64EncodeUtf8(IMAGE_UPLOAD_WORKFLOW_YAML)
+      })
+    });
+    if (!put.ok) {
+      throw new Error(`Failed to commit workflow (status ${put.status})`);
+    }
+    return 'installed';
+  } catch (error) {
+    console.error(`Workflow install failed for ${fullName}: ${error.message}`);
+    return 'error';
+  }
+}
+
+async function installWorkflowInRepos(env, installationId, repositories) {
+  let token;
+  try {
+    token = await createInstallationToken(env, installationId);
+  } catch (error) {
+    console.error(`Could not create installation token: ${error.message}`);
+    return;
+  }
+  for (const repo of repositories) {
+    if (repo && repo.full_name) {
+      const result = await installWorkflowInRepo(env, token, repo.full_name);
+      console.log(`image-upload workflow for ${repo.full_name}: ${result}`);
+    }
+  }
+}
+
+// Handle POST /webhook (GitHub App webhook endpoint)
+export async function handleGitHubWebhook(request, env, ctx) {
+  if (!env.GITHUB_WEBHOOK_SECRET) {
+    return jsonResponse({ error: 'Webhook not configured (GITHUB_WEBHOOK_SECRET missing)' }, 503);
+  }
+
+  const rawBody = await request.text();
+  const signature = request.headers.get('x-hub-signature-256');
+  if (!(await verifyWebhookSignature(env.GITHUB_WEBHOOK_SECRET, rawBody, signature))) {
+    return jsonResponse({ error: 'invalid_signature' }, 401);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return jsonResponse({ error: 'invalid_payload' }, 400);
+  }
+
+  const event = request.headers.get('x-github-event');
+  let repositories = [];
+  if (event === 'installation' && payload.action === 'created') {
+    repositories = payload.repositories || [];
+  } else if (event === 'installation_repositories' && payload.action === 'added') {
+    repositories = payload.repositories_added || [];
+  } else {
+    return jsonResponse({ status: 'ignored' });
+  }
+
+  const installationId = payload.installation && payload.installation.id;
+  if (!installationId || repositories.length === 0) {
+    return jsonResponse({ status: 'ignored' });
+  }
+
+  const work = installWorkflowInRepos(env, installationId, repositories);
+  if (ctx && typeof ctx.waitUntil === 'function') {
+    // Respond to GitHub immediately; the commits happen in the background
+    ctx.waitUntil(work);
+  } else {
+    await work;
+  }
+
+  return jsonResponse({ status: 'accepted', repositories: repositories.length }, 202);
+}

--- a/app-install.test.js
+++ b/app-install.test.js
@@ -1,0 +1,153 @@
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+
+import { handleGitHubWebhook, installWorkflowInRepo } from './app-install.js';
+import { IMAGE_UPLOAD_WORKFLOW_PATH } from './workflow-template.js';
+
+const SECRET = 'test-webhook-secret';
+
+function sign(body) {
+  return 'sha256=' + crypto.createHmac('sha256', SECRET).update(body).digest('hex');
+}
+
+function webhookRequest(event, payload, { signature } = {}) {
+  const body = JSON.stringify(payload);
+  return new Request('https://worker.example/webhook', {
+    method: 'POST',
+    headers: {
+      'x-github-event': event,
+      'x-hub-signature-256': signature !== undefined ? signature : sign(body),
+      'Content-Type': 'application/json'
+    },
+    body
+  });
+}
+
+// A well-formed but worthless RSA key is overkill for these tests: token
+// creation is exercised through a stubbed fetch, and the JWT signing path
+// is short-circuited by making the token request the first fetch failure
+// where needed. We stub global.fetch and record calls.
+let fetchCalls;
+let fetchResponses;
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchResponses = [];
+  global.fetch = async (url, init = {}) => {
+    fetchCalls.push({ url: String(url), method: init.method || 'GET', body: init.body });
+    const next = fetchResponses.shift();
+    if (!next) {
+      return new Response('{}', { status: 500 });
+    }
+    return next;
+  };
+});
+
+afterEach(() => {
+  global.fetch = realFetch;
+});
+
+const ENV = {
+  GITHUB_WEBHOOK_SECRET: SECRET,
+  GITHUB_APP_ID: '12345',
+  // Tests never reach real JWT signing unless noted; see stubs
+  GITHUB_APP_PRIVATE_KEY: 'unused',
+  GITHUB_API: 'https://api.github.example'
+};
+
+describe('handleGitHubWebhook', () => {
+  test('returns 503 when the webhook secret is not configured', async () => {
+    const response = await handleGitHubWebhook(webhookRequest('ping', {}), {});
+    assert.equal(response.status, 503);
+  });
+
+  test('rejects invalid signatures', async () => {
+    const request = webhookRequest('installation', { action: 'created' }, { signature: 'sha256=' + '0'.repeat(64) });
+    const response = await handleGitHubWebhook(request, ENV);
+    assert.equal(response.status, 401);
+  });
+
+  test('rejects missing signatures', async () => {
+    const request = webhookRequest('installation', { action: 'created' }, { signature: '' });
+    const response = await handleGitHubWebhook(request, ENV);
+    assert.equal(response.status, 401);
+  });
+
+  test('ignores unrelated events', async () => {
+    const response = await handleGitHubWebhook(webhookRequest('push', { ref: 'refs/heads/main' }), ENV);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.status, 'ignored');
+    assert.equal(fetchCalls.length, 0);
+  });
+
+  test('ignores installation deletions', async () => {
+    const response = await handleGitHubWebhook(
+      webhookRequest('installation', { action: 'deleted', installation: { id: 1 }, repositories: [{ full_name: 'octo/demo' }] }),
+      ENV
+    );
+    const body = await response.json();
+    assert.equal(body.status, 'ignored');
+    assert.equal(fetchCalls.length, 0);
+  });
+
+  test('accepts installation created events and reports repo count', async () => {
+    // Token creation fails fast in this test (empty fetch queue → 500),
+    // which exercises the accepted-response path without real GitHub calls.
+    const payload = {
+      action: 'created',
+      installation: { id: 42 },
+      repositories: [{ full_name: 'octo/demo' }, { full_name: 'octo/two' }]
+    };
+    const response = await handleGitHubWebhook(webhookRequest('installation', payload), ENV);
+    assert.equal(response.status, 202);
+    const body = await response.json();
+    assert.equal(body.status, 'accepted');
+    assert.equal(body.repositories, 2);
+  });
+
+  test('accepts installation_repositories added events', async () => {
+    const payload = {
+      action: 'added',
+      installation: { id: 42 },
+      repositories_added: [{ full_name: 'octo/three' }]
+    };
+    const response = await handleGitHubWebhook(webhookRequest('installation_repositories', payload), ENV);
+    assert.equal(response.status, 202);
+    const body = await response.json();
+    assert.equal(body.repositories, 1);
+  });
+});
+
+describe('installWorkflowInRepo', () => {
+  test('commits the workflow when the repo does not have one', async () => {
+    fetchResponses.push(new Response('{}', { status: 404 })); // existence check
+    fetchResponses.push(new Response('{}', { status: 201 })); // PUT contents
+
+    const result = await installWorkflowInRepo(ENV, 'ghs_token', 'octo/demo');
+    assert.equal(result, 'installed');
+    assert.equal(fetchCalls.length, 2);
+    assert.ok(fetchCalls[0].url.endsWith(`/repos/octo/demo/contents/${IMAGE_UPLOAD_WORKFLOW_PATH}`));
+    assert.equal(fetchCalls[1].method, 'PUT');
+    const putBody = JSON.parse(fetchCalls[1].body);
+    assert.match(putBody.message, /image-upload workflow/);
+    const committed = Buffer.from(putBody.content, 'base64').toString();
+    assert.match(committed, /workflow_dispatch/);
+    assert.match(committed, /id-token: write/);
+  });
+
+  test('skips repos that already have the workflow', async () => {
+    fetchResponses.push(new Response('{}', { status: 200 }));
+    const result = await installWorkflowInRepo(ENV, 'ghs_token', 'octo/demo');
+    assert.equal(result, 'exists');
+    assert.equal(fetchCalls.length, 1);
+  });
+
+  test('reports errors without throwing', async () => {
+    fetchResponses.push(new Response('{}', { status: 403 }));
+    const result = await installWorkflowInRepo(ENV, 'ghs_token', 'octo/demo');
+    assert.equal(result, 'error');
+  });
+});

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -1,0 +1,191 @@
+# Design: `gh image` — Image/Video Uploads for Coding Agents
+
+## Problem
+
+`gh` on its own cannot attach images to a PR or issue
+([cli/cli#12960](https://github.com/cli/cli/issues/12960)). GitHub's
+user-attachments upload endpoint is not exposed via the API, so coding agents
+that want to include a screenshot or screen recording in a PR description have
+no sanctioned path. The existing workaround,
+[gh-image](https://github.com/drogers0/gh-image), drives a remote-controlled
+browser through the web UI — heavyweight, brittle, and hard to run headless.
+
+This design provides a different approach: content-addressed uploads to a
+Cloudflare R2 bucket, brokered by the as-a-bot Worker, and gated by a GitHub
+Actions workflow that only repository maintainers can dispatch.
+
+## Goals
+
+- `gh image <file>` returns a stable, serveable URL for an image or video that
+  can be embedded in PR/issue Markdown.
+- No GitHub credentials or cloud credentials on the client beyond what `gh`
+  already has.
+- Upload capability is gated on repository write access (the same bar as
+  pushing code), enforced by GitHub itself.
+- Content-addressed storage: the same file uploaded twice yields the same URL,
+  and a URL can never silently change content.
+
+## Non-goals
+
+- Attaching files to GitHub's own `user-images`/`user-attachments` CDN (no API
+  exists — that is the premise of the problem).
+- Access control on *reads*. Serve URLs are public (but unguessable without
+  the content hash for private content).
+
+## Architecture
+
+Three components, mirroring the mcpecrets pattern (Worker for compute, GitHub
+Actions for the trust boundary):
+
+1. **`gh image` command** (ai-aligned-gh wrapper) — computes the content hash,
+   dispatches the workflow, polls the Worker, uploads the file.
+2. **`image-upload.yml` workflow** (committed to each participating repo,
+   template in [`templates/image-upload.yml`](../templates/image-upload.yml)) —
+   holds the R2 credentials as Actions secrets, pre-signs a checksum-bound PUT
+   URL, and registers it with the Worker. GitHub enforces that only users with
+   write access can dispatch it.
+3. **as-a-bot Worker** — temporary mailbox for pre-signed URLs (KV, short TTL)
+   and permanent serve path for uploaded objects (R2 binding).
+
+```
+gh image shot.png
+   │
+   │ 1. sha256(file) = <hash>
+   │ 2. gh workflow run image-upload.yml -f hash=<hash> -f ext=png
+   ▼                                  (requires write access — GitHub enforces)
+GitHub Actions (target repo)
+   │ 3. pre-sign PUT https://<account>.r2.cloudflarestorage.com/<bucket>/
+   │       <owner>/<repo>/<hash>.png  (x-amz-checksum-sha256 signed in)
+   │ 4. POST /image-upload/offer  (Bearer: GitHub OIDC token)
+   ▼
+as-a-bot Worker ──── KV: offer:<owner>/<repo>/<hash>.png  (TTL ≤ 15 min)
+   ▲                                                │
+   │ 5. GET /image-upload/status?...  (poll)        │
+   │    → { status: "ready", upload_url, ... }      │
+gh image                                            │
+   │ 6. PUT file → pre-signed R2 URL                │
+   ▼                                                ▼
+R2 bucket: <owner>/<repo>/<hash>.png ◄──── 7. GET /i/<owner>/<repo>/<hash>.png
+                                                (served by Worker, immutable)
+```
+
+### Flow in detail
+
+1. `gh image shot.png` computes `hash = SHA-256(file)` (hex) and derives the
+   extension from the filename.
+2. **Dedupe check**: `HEAD /i/<owner>/<repo>/<hash>.png` — if the object
+   already exists (content-addressed), print the URL and stop.
+3. `gh workflow run image-upload.yml -f hash=<hash> -f ext=png` in the target
+   repo. Owner/repo come from the working directory or `--repo`. Under an AI
+   tool the dispatch uses the as-a-bot user-to-server token, so the run is
+   attributed like every other write in the wrapper.
+4. The workflow job:
+   - validates `hash`/`ext` inputs,
+   - pre-signs `PUT <bucket>/<owner>/<repo>/<hash>.<ext>` with the AWS SDK
+     against the R2 S3 endpoint, **including `x-amz-checksum-sha256` as a
+     signed header** (15-minute expiry),
+   - requests a GitHub OIDC token (`id-token: write`) with audience
+     `as-a-bot-images`,
+   - `POST /image-upload/offer` to the Worker with the pre-signed URL, the
+     required upload headers, and the coordinates.
+5. The Worker verifies the OIDC token (signature against GitHub's JWKS,
+   issuer, audience, expiry) and that the token's `repository` claim matches
+   the posted `owner/repo`, then stores the offer in KV keyed
+   `offer:<owner>/<repo>/<hash>.<ext>` with a TTL matching the URL expiry.
+6. `gh image` polls `GET /image-upload/status?owner=&repo=&hash=&ext=` (every
+   3 s, default timeout 180 s):
+   - `202 {"status":"pending"}` — workflow hasn't reported yet,
+   - `200 {"status":"ready", upload_url, upload_headers, serve_url}`,
+   - `200 {"status":"uploaded", serve_url}` — object already in R2.
+7. `gh image` PUTs the file to `upload_url` with the returned headers
+   (`x-amz-checksum-sha256: <base64 hash>` + `Content-Type`). R2 rejects the
+   upload if the body doesn't match the signed checksum.
+8. `gh image` verifies `HEAD <serve_url>` succeeds and prints the serve URL:
+   `https://<worker>/i/<owner>/<repo>/<hash>.<ext>`.
+
+## Worker API
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/image-upload/offer` | POST | GitHub Actions OIDC (aud `as-a-bot-images`) | Workflow registers a pre-signed upload URL |
+| `/image-upload/status` | GET | none | Client polls for the upload URL / upload state |
+| `/i/{owner}/{repo}/{hash}.{ext}` | GET, HEAD | none | Serve the stored object (immutable caching) |
+
+Offer payload:
+
+```json
+{
+  "owner": "ai-ecoverse", "repo": "as-a-bot",
+  "hash": "<64 hex chars>", "ext": "png",
+  "upload_url": "https://<account>.r2.cloudflarestorage.com/...",
+  "upload_headers": { "x-amz-checksum-sha256": "<base64>" },
+  "expires_in": 900
+}
+```
+
+The Worker validates: hash format, extension allowlist (`png jpg jpeg gif webp
+svg avif mp4 mov webm`), `upload_url` host must be `*.r2.cloudflarestorage.com`,
+and OIDC `repository` claim == `owner/repo`.
+
+## Storage layout & bindings
+
+- **R2 bucket** (`IMAGES` binding, bucket `as-a-bot-images`):
+  objects at `<owner>/<repo>/<hash>.<ext>`. Content-addressed and immutable.
+- **KV** (`IMAGE_OFFERS` binding): transient offers at
+  `offer:<owner>/<repo>/<hash>.<ext>`, TTL-bounded (60 s–1 h, default 15 min).
+
+## Trust model
+
+| Threat | Mitigation |
+|--------|-----------|
+| Arbitrary users minting upload URLs | Only the target repo's workflow can register offers (OIDC `repository` claim), and only users with **write access** can dispatch `workflow_dispatch` — GitHub enforces this. |
+| Forged offers (attacker POSTs a malicious `upload_url`) | Offer endpoint requires a valid GitHub OIDC token for the exact repo; `upload_url` host is restricted to R2. |
+| Stolen upload URL (workflow inputs are visible to anyone with read access on public repos, so the poll coordinates are not secret) | The pre-signed URL has `x-amz-checksum-sha256` in its signed headers: it can **only** upload content matching the requested hash. Worst case, an attacker uploads the identical bytes the maintainer was about to upload. |
+| Content swap after publication | Keys are content-addressed; the serve path re-checks the stored R2 SHA-256 checksum against the hash in the key and refuses to serve mismatches. URLs are immutable. |
+| Credential blast radius | R2 credentials live only as Actions secrets in participating repos (mcpecrets pattern) and never reach the client or the Worker. Note: any repo holding the credentials can write any key in the shared bucket — use per-org buckets/credentials if org-level isolation matters. |
+| SVG script execution | Served with `X-Content-Type-Options: nosniff` and a restrictive `Content-Security-Policy` (and GitHub proxies embedded images through Camo anyway). |
+
+## Alternatives considered
+
+- **Browser automation (gh-image)**: works, but needs a full browser, user
+  session cookies, and breaks whenever the web UI changes.
+- **Worker mints the pre-signed URL directly (client → Worker with OIDC-less
+  auth)**: fewer moving parts, but the Worker would need R2 credentials plus
+  its own notion of "who may upload to owner/repo" — reimplementing GitHub's
+  permission model. Dispatching a workflow delegates the maintainer check to
+  GitHub, and keeps the Worker credential-free (mcpecrets showed this pattern
+  works well).
+- **Repo-committed uploads (orphan branch / git LFS)**: pollutes history,
+  size limits, and `raw.githubusercontent.com` is not a good video host.
+
+## Repo setup (one-time, per repo)
+
+1. Install the [as-a-bot app](https://github.com/apps/as-a-bot) (for AI
+   attribution of the dispatch; optional for human use).
+2. Copy [`templates/image-upload.yml`](../templates/image-upload.yml) to
+   `.github/workflows/image-upload.yml`.
+3. Add Actions secrets (repo- or org-level): `R2_ACCOUNT_ID`,
+   `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (an R2 API token scoped to
+   object writes on the bucket). Optional Actions variables: `R2_BUCKET`
+   (default `as-a-bot-images`), `AS_A_BOT_URL` (default
+   `https://as-bot-worker.minivelos.workers.dev`).
+
+## Worker setup (one-time, operator)
+
+```sh
+wrangler r2 bucket create as-a-bot-images   # bucket for uploads
+wrangler kv namespace create IMAGE_OFFERS   # transient offer mailbox
+wrangler deploy
+```
+
+The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) and
+the OIDC audience via the `IMAGE_OIDC_AUDIENCE` var.
+
+## Limitations / future work
+
+- First upload of a file pays GitHub Actions queue latency (typically
+  10–30 s). Re-uploads of known content are instant (dedupe via HEAD).
+- No garbage collection; content-addressed objects are kept forever. An R2
+  lifecycle rule can cap this if needed.
+- No file-size limit is enforced beyond R2's single-PUT limit (~5 GB);
+  a `size` workflow input with a signed `content-length-range` could be added.

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -226,8 +226,10 @@ wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-
 
 Deployment itself is CI-driven (`.github/workflows/deploy.yml`): every push
 to `main` runs the tests, syncs `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` /
-`GITHUB_WEBHOOK_SECRET` from Actions secrets into Worker secrets, and runs
-`wrangler deploy` (authenticated by the `CLOUDFLARE_TOKEN` Actions secret).
+`GH_WEBHOOK_SECRET` from Actions secrets into Worker secrets (the last one
+lands as `GITHUB_WEBHOOK_SECRET` — Actions secret names may not start with
+`GITHUB_`), and runs `wrangler deploy` (authenticated by the
+`CLOUDFLARE_TOKEN` Actions secret).
 The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) along
 with the `R2_ACCOUNT_ID` / `R2_BUCKET` / `IMAGE_OIDC_AUDIENCE` vars.
 

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -222,12 +222,12 @@ automatically. That's it — no secrets, no variables.
 ```sh
 wrangler r2 bucket create as-a-bot-images
 wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-days 90
-wrangler secret put R2_ACCESS_KEY_ID       # R2 S3 credential (pre-signing only)
-wrangler secret put R2_SECRET_ACCESS_KEY
-wrangler secret put GITHUB_WEBHOOK_SECRET
-wrangler deploy
 ```
 
+Deployment itself is CI-driven (`.github/workflows/deploy.yml`): every push
+to `main` runs the tests, syncs `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` /
+`GITHUB_WEBHOOK_SECRET` from Actions secrets into Worker secrets, and runs
+`wrangler deploy` (authenticated by the `CLOUDFLARE_TOKEN` Actions secret).
 The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) along
 with the `R2_ACCOUNT_ID` / `R2_BUCKET` / `IMAGE_OIDC_AUDIENCE` vars.
 

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -12,18 +12,22 @@ browser through the web UI — heavyweight, brittle, and hard to run headless.
 
 This design provides a different approach: content-addressed uploads to a
 Cloudflare R2 bucket, brokered by the as-a-bot Worker, and gated by a GitHub
-Actions workflow that only repository maintainers can dispatch.
+Actions workflow that only repository maintainers can dispatch. Installing the
+as-a-bot GitHub App is the only setup: the app commits the workflow to the
+repository automatically, and the repository needs **no secrets**.
 
 ## Goals
 
 - `gh image <file>` returns a stable, serveable URL for an image or video that
   can be embedded in PR/issue Markdown.
-- No GitHub credentials or cloud credentials on the client beyond what `gh`
-  already has.
+- Zero per-repo configuration beyond installing the GitHub App: no secrets,
+  no manual workflow copying.
 - Upload capability is gated on repository write access (the same bar as
   pushing code), enforced by GitHub itself.
 - Content-addressed storage: the same file uploaded twice yields the same URL,
   and a URL can never silently change content.
+- Bounded storage: uploads expire after 90 days; re-uploading the same file
+  renews it at the same URL.
 
 ## Non-goals
 
@@ -39,34 +43,46 @@ Actions for the trust boundary):
 
 1. **`gh image` command** (ai-aligned-gh wrapper) — computes the content hash,
    dispatches the workflow, polls the Worker, uploads the file.
-2. **`image-upload.yml` workflow** (committed to each participating repo,
-   template in [`templates/image-upload.yml`](../templates/image-upload.yml)) —
-   holds the R2 credentials as Actions secrets, pre-signs a checksum-bound PUT
-   URL, and registers it with the Worker. GitHub enforces that only users with
-   write access can dispatch it.
-3. **as-a-bot Worker** — temporary mailbox for pre-signed URLs (KV, short TTL)
-   and permanent serve path for uploaded objects (R2 binding).
+2. **`image-upload.yml` workflow** — a thin, secret-free authorization relay,
+   committed to each repo automatically by the app on installation
+   (`app-install.js`; canonical copy in `workflow-template.js`, mirrored in
+   [`templates/image-upload.yml`](../templates/image-upload.yml) for manual
+   installs). GitHub enforces that only users with write access can dispatch
+   it; its OIDC token proves *which repository* is asking.
+3. **as-a-bot Worker** — verifies the OIDC token, **mints the pre-signed R2
+   PUT URL itself** (`r2-presign.js`, no dependencies) using R2 credentials
+   that live only as Worker secrets, stores it briefly in KV, and serves
+   uploaded objects from R2.
 
 ```
+as-a-bot app installed on owner/repo
+   │ webhook: installation created / repos added
+   ▼
+Worker POST /webhook ──► commits .github/workflows/image-upload.yml
+                          (installation token; skips if file exists)
+
 gh image shot.png
    │
    │ 1. sha256(file) = <hash>
    │ 2. gh workflow run image-upload.yml -f hash=<hash> -f ext=png
    ▼                                  (requires write access — GitHub enforces)
-GitHub Actions (target repo)
-   │ 3. pre-sign PUT https://<account>.r2.cloudflarestorage.com/<bucket>/
-   │       <owner>/<repo>/<hash>.png  (x-amz-checksum-sha256 signed in)
-   │ 4. POST /image-upload/offer  (Bearer: GitHub OIDC token)
+GitHub Actions (target repo, no secrets)
+   │ 3. POST /image-upload/offer {hash, ext}   (Bearer: GitHub OIDC token)
    ▼
-as-a-bot Worker ──── KV: offer:<owner>/<repo>/<hash>.png  (TTL ≤ 15 min)
+as-a-bot Worker
+   │ 4. derive owner/repo from OIDC `repository` claim
+   │ 5. pre-sign PUT https://<account>.r2.cloudflarestorage.com/<bucket>/
+   │       <owner>/<repo>/<hash>.png  (x-amz-checksum-sha256 signed in)
+   │ 6. KV: offer:<owner>/<repo>/<hash>.png  (TTL ≤ 15 min)
    ▲                                                │
-   │ 5. GET /image-upload/status?...  (poll)        │
+   │ 7. GET /image-upload/status?...  (poll)        │
    │    → { status: "ready", upload_url, ... }      │
 gh image                                            │
-   │ 6. PUT file → pre-signed R2 URL                │
+   │ 8. PUT file → pre-signed R2 URL                │
    ▼                                                ▼
-R2 bucket: <owner>/<repo>/<hash>.png ◄──── 7. GET /i/<owner>/<repo>/<hash>.png
-                                                (served by Worker, immutable)
+R2 bucket: <owner>/<repo>/<hash>.png ◄──── 9. GET /i/<owner>/<repo>/<hash>.png
+                                             (served by Worker, immutable,
+                                              expires after 90 days)
 ```
 
 ### Flow in detail
@@ -79,19 +95,18 @@ R2 bucket: <owner>/<repo>/<hash>.png ◄──── 7. GET /i/<owner>/<repo>/<h
    repo. Owner/repo come from the working directory or `--repo`. Under an AI
    tool the dispatch uses the as-a-bot user-to-server token, so the run is
    attributed like every other write in the wrapper.
-4. The workflow job:
-   - validates `hash`/`ext` inputs,
-   - pre-signs `PUT <bucket>/<owner>/<repo>/<hash>.<ext>` with the AWS SDK
-     against the R2 S3 endpoint, **including `x-amz-checksum-sha256` as a
-     signed header** (15-minute expiry),
-   - requests a GitHub OIDC token (`id-token: write`) with audience
-     `as-a-bot-images`,
-   - `POST /image-upload/offer` to the Worker with the pre-signed URL, the
-     required upload headers, and the coordinates.
+4. The workflow job validates its inputs, requests a GitHub OIDC token
+   (`id-token: write`, audience `as-a-bot-images`), and POSTs
+   `{hash, ext}` to `/image-upload/offer`. That is all it does — it holds no
+   credentials and receives back only the serve URL (never the upload URL,
+   which must not appear in publicly readable run logs).
 5. The Worker verifies the OIDC token (signature against GitHub's JWKS,
-   issuer, audience, expiry) and that the token's `repository` claim matches
-   the posted `owner/repo`, then stores the offer in KV keyed
-   `offer:<owner>/<repo>/<hash>.<ext>` with a TTL matching the URL expiry.
+   issuer, audience, expiry) and derives `owner/repo` **from the token's
+   `repository` claim** — coordinates cannot be spoofed. It mints a pre-signed
+   `PUT <bucket>/<owner>/<repo>/<hash>.<ext>` URL (SigV4 query auth,
+   15-minute expiry) with **`x-amz-checksum-sha256` as a signed header**, and
+   stores the offer in KV keyed `offer:<owner>/<repo>/<hash>.<ext>` with a
+   matching TTL.
 6. `gh image` polls `GET /image-upload/status?owner=&repo=&hash=&ext=` (every
    3 s, default timeout 180 s):
    - `202 {"status":"pending"}` — workflow hasn't reported yet,
@@ -107,27 +122,20 @@ R2 bucket: <owner>/<repo>/<hash>.png ◄──── 7. GET /i/<owner>/<repo>/<h
 
 | Endpoint | Method | Auth | Purpose |
 |----------|--------|------|---------|
-| `/image-upload/offer` | POST | GitHub Actions OIDC (aud `as-a-bot-images`) | Workflow registers a pre-signed upload URL |
+| `/webhook` | POST | HMAC (`X-Hub-Signature-256`) | App installation events → auto-commit the workflow |
+| `/image-upload/offer` | POST | GitHub Actions OIDC (aud `as-a-bot-images`) | Workflow requests a pre-signed upload URL |
 | `/image-upload/status` | GET | none | Client polls for the upload URL / upload state |
 | `/i/{owner}/{repo}/{hash}.{ext}` | GET, HEAD | none | Serve the stored object (immutable caching) |
 
-Offer payload:
+Offer payload (owner/repo come from the OIDC token, never the body):
 
 ```json
-{
-  "owner": "ai-ecoverse", "repo": "as-a-bot",
-  "hash": "<64 hex chars>", "ext": "png",
-  "upload_url": "https://<account>.r2.cloudflarestorage.com/...",
-  "upload_headers": { "x-amz-checksum-sha256": "<base64>" },
-  "expires_in": 900
-}
+{ "hash": "<64 hex chars>", "ext": "png", "expires_in": 900 }
 ```
 
-The Worker validates: hash format, extension allowlist (`png jpg jpeg gif webp
-svg avif mp4 mov webm`), `upload_url` host must be `*.r2.cloudflarestorage.com`,
-`upload_headers` must carry `x-amz-checksum-sha256` equal to the base64
-encoding of `hash` (the checksum binding is mandatory, not optional), and the
-OIDC `repository` claim must equal `owner/repo`.
+The Worker validates hash format and the extension allowlist (`png jpg jpeg
+gif webp svg avif mp4 mov webm`), and responds with `{status, serve_url}`
+only.
 
 ## Storage layout & bindings
 
@@ -135,59 +143,100 @@ OIDC `repository` claim must equal `owner/repo`.
   objects at `<owner>/<repo>/<hash>.<ext>`. Content-addressed and immutable.
 - **KV** (`IMAGE_OFFERS` binding): transient offers at
   `offer:<owner>/<repo>/<hash>.<ext>`, TTL-bounded (60 s–1 h, default 15 min).
+- **Worker secrets**: `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` (S3
+  credentials used only for pre-signing; never leave the Worker),
+  `GITHUB_WEBHOOK_SECRET`, plus the existing `GITHUB_APP_ID` /
+  `GITHUB_APP_PRIVATE_KEY` used to mint installation tokens for the
+  workflow auto-install.
+
+## Upload lifetime (90-day TTL)
+
+Uploads are kept for 90 days, enforced in two layers:
+
+1. **Serve-time enforcement (Worker)**: objects older than 90 days
+   (`uploaded` timestamp from R2) are refused with `410 Gone` and deleted on
+   access; the status endpoint stops reporting them as `uploaded`, so a
+   re-run of `gh image` transparently re-uploads and renews the same URL.
+   `Cache-Control: max-age` is capped at the object's remaining lifetime.
+2. **Storage reclamation (R2 lifecycle rule)**: a bucket lifecycle rule
+   deletes objects 90 days after creation even if they are never requested
+   again. Set once with:
+   ```sh
+   npx wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-days 90
+   ```
+
+Embedded Markdown images older than 90 days therefore break unless renewed —
+that is the intended trade-off for bounded storage. Re-running
+`gh image <same file>` restores the identical URL.
 
 ## Trust model
 
 | Threat | Mitigation |
 |--------|-----------|
-| Arbitrary users minting upload URLs | Only the target repo's workflow can register offers (OIDC `repository` claim), and only users with **write access** can dispatch `workflow_dispatch` — GitHub enforces this. |
-| Forged offers (attacker POSTs a malicious `upload_url`) | Offer endpoint requires a valid GitHub OIDC token for the exact repo; `upload_url` host is restricted to R2. |
-| Stolen upload URL (workflow inputs are visible to anyone with read access on public repos, so the poll coordinates are not secret) | The pre-signed URL has `x-amz-checksum-sha256` in its signed headers: it can **only** upload content matching the requested hash. Worst case, an attacker uploads the identical bytes the maintainer was about to upload. |
-| Content swap after publication | Keys are content-addressed; the serve path re-checks the stored R2 SHA-256 checksum against the hash in the key and refuses to serve mismatches — or objects with no stored checksum at all (e.g. written out-of-band without `ChecksumSHA256`). URLs are immutable. |
-| Credential blast radius | R2 credentials live only as Actions secrets in participating repos (mcpecrets pattern) and never reach the client or the Worker. Note: any repo holding the credentials can write any key in the shared bucket — use per-org buckets/credentials if org-level isolation matters. |
+| Arbitrary users minting upload URLs | Offers require a GitHub Actions OIDC token, and only users with **write access** can dispatch `workflow_dispatch` — GitHub enforces this. |
+| Spoofed coordinates (uploading into another repo's namespace) | `owner/repo` are derived exclusively from the OIDC token's `repository` claim, which GitHub controls. |
+| Stolen upload URL (workflow inputs are visible to anyone with read access on public repos, so the poll coordinates are not secret) | The pre-signed URL has `x-amz-checksum-sha256` in its signed headers: it can **only** upload content matching the requested hash. Worst case, an attacker uploads the identical bytes the maintainer was about to upload. The upload URL is also never returned to the workflow (run logs are readable), only via the status endpoint. |
+| Content swap after publication | Keys are content-addressed; the serve path refuses objects whose stored R2 SHA-256 checksum is missing or does not match the hash in the key. URLs are immutable for their lifetime. |
+| Credential blast radius | R2 credentials exist in exactly one place: Worker secrets. Repositories hold no secrets at all. Compromising a repo yields nothing; compromising a workflow run yields at most checksum-bound upload URLs for that repo's own namespace. |
+| Forged webhook (tricking the Worker into committing workflows) | `/webhook` verifies `X-Hub-Signature-256` (HMAC over the raw body with the app's webhook secret) before acting; the auto-install also never overwrites an existing workflow file. |
 | SVG script execution | Served with `X-Content-Type-Options: nosniff` and a restrictive `Content-Security-Policy` (and GitHub proxies embedded images through Camo anyway). |
 
 ## Alternatives considered
 
 - **Browser automation (gh-image)**: works, but needs a full browser, user
   session cookies, and breaks whenever the web UI changes.
-- **Worker mints the pre-signed URL directly (client → Worker with OIDC-less
-  auth)**: fewer moving parts, but the Worker would need R2 credentials plus
-  its own notion of "who may upload to owner/repo" — reimplementing GitHub's
-  permission model. Dispatching a workflow delegates the maintainer check to
-  GitHub, and keeps the Worker credential-free (mcpecrets showed this pattern
-  works well).
+- **Workflow pre-signs the URL itself (R2 credentials as Actions secrets)**:
+  the initial design. Rejected because it puts cloud credentials in every
+  participating repo (painful to onboard, wide blast radius: any repo holding
+  the credentials can write any key in the shared bucket) and requires manual
+  setup. With the Worker minting URLs, repos need zero secrets and writes are
+  confined to the calling repo's own prefix.
+- **Client uploads through the Worker (no pre-signed URL)**: simplest, but
+  Workers cap request bodies well below R2's 5 GB single-PUT limit, which
+  matters for videos; direct-to-R2 also keeps large transfers off the Worker.
 - **Repo-committed uploads (orphan branch / git LFS)**: pollutes history,
   size limits, and `raw.githubusercontent.com` is not a good video host.
 
-## Repo setup (one-time, per repo)
+## Setup
 
-1. Install the [as-a-bot app](https://github.com/apps/as-a-bot) (for AI
-   attribution of the dispatch; optional for human use).
-2. Copy [`templates/image-upload.yml`](../templates/image-upload.yml) to
-   `.github/workflows/image-upload.yml`.
-3. Add Actions secrets (repo- or org-level): `R2_ACCOUNT_ID`,
-   `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (an R2 API token scoped to
-   object writes on the bucket). Optional Actions variables: `R2_BUCKET`
-   (default `as-a-bot-images`), `AS_A_BOT_URL` (default
-   `https://as-bot-worker.minivelos.workers.dev`).
+### Repository (one-time)
 
-## Worker setup (one-time, operator)
+Install the [as-a-bot app](https://github.com/apps/as-a-bot) on the
+repository. The app commits `.github/workflows/image-upload.yml`
+automatically. That's it — no secrets, no variables.
+
+(Manual alternative: copy
+[`templates/image-upload.yml`](../templates/image-upload.yml) to
+`.github/workflows/image-upload.yml`.)
+
+### GitHub App (operator, one-time)
+
+- Webhook URL: `https://<worker>/webhook`, with a webhook secret
+  (`GITHUB_WEBHOOK_SECRET`).
+- Subscribe to **Installation** events.
+- Repository permissions: **Contents: Read & write**, **Workflows: Read &
+  write** (required to commit workflow files).
+
+### Worker (operator, one-time)
 
 ```sh
-wrangler r2 bucket create as-a-bot-images   # bucket for uploads
-wrangler kv namespace create IMAGE_OFFERS   # transient offer mailbox
+wrangler r2 bucket create as-a-bot-images
+wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-days 90
+wrangler secret put R2_ACCESS_KEY_ID       # R2 S3 credential (pre-signing only)
+wrangler secret put R2_SECRET_ACCESS_KEY
+wrangler secret put GITHUB_WEBHOOK_SECRET
 wrangler deploy
 ```
 
-The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) and
-the OIDC audience via the `IMAGE_OIDC_AUDIENCE` var.
+The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) along
+with the `R2_ACCOUNT_ID` / `R2_BUCKET` / `IMAGE_OIDC_AUDIENCE` vars.
 
 ## Limitations / future work
 
 - First upload of a file pays GitHub Actions queue latency (typically
-  10–30 s). Re-uploads of known content are instant (dedupe via HEAD).
-- No garbage collection; content-addressed objects are kept forever. An R2
-  lifecycle rule can cap this if needed.
+  10–30 s). Re-uploads of known content are instant (dedupe via HEAD) —
+  until they expire.
+- Uploads expire after 90 days (see above); embedded URLs must be renewed by
+  re-running `gh image` on the same file if they should outlive that.
 - No file-size limit is enforced beyond R2's single-PUT limit (~5 GB);
   a `size` workflow input with a signed `content-length-range` could be added.

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -125,7 +125,9 @@ Offer payload:
 
 The Worker validates: hash format, extension allowlist (`png jpg jpeg gif webp
 svg avif mp4 mov webm`), `upload_url` host must be `*.r2.cloudflarestorage.com`,
-and OIDC `repository` claim == `owner/repo`.
+`upload_headers` must carry `x-amz-checksum-sha256` equal to the base64
+encoding of `hash` (the checksum binding is mandatory, not optional), and the
+OIDC `repository` claim must equal `owner/repo`.
 
 ## Storage layout & bindings
 
@@ -141,7 +143,7 @@ and OIDC `repository` claim == `owner/repo`.
 | Arbitrary users minting upload URLs | Only the target repo's workflow can register offers (OIDC `repository` claim), and only users with **write access** can dispatch `workflow_dispatch` — GitHub enforces this. |
 | Forged offers (attacker POSTs a malicious `upload_url`) | Offer endpoint requires a valid GitHub OIDC token for the exact repo; `upload_url` host is restricted to R2. |
 | Stolen upload URL (workflow inputs are visible to anyone with read access on public repos, so the poll coordinates are not secret) | The pre-signed URL has `x-amz-checksum-sha256` in its signed headers: it can **only** upload content matching the requested hash. Worst case, an attacker uploads the identical bytes the maintainer was about to upload. |
-| Content swap after publication | Keys are content-addressed; the serve path re-checks the stored R2 SHA-256 checksum against the hash in the key and refuses to serve mismatches. URLs are immutable. |
+| Content swap after publication | Keys are content-addressed; the serve path re-checks the stored R2 SHA-256 checksum against the hash in the key and refuses to serve mismatches — or objects with no stored checksum at all (e.g. written out-of-band without `ChecksumSHA256`). URLs are immutable. |
 | Credential blast radius | R2 credentials live only as Actions secrets in participating repos (mcpecrets pattern) and never reach the client or the Worker. Note: any repo holding the credentials can write any key in the shared bucket — use per-org buckets/credentials if org-level isolation matters. |
 | SVG script execution | Served with `X-Content-Type-Options: nosniff` and a restrictive `Content-Security-Policy` (and GitHub proxies embedded images through Camo anyway). |
 

--- a/github-oidc.js
+++ b/github-oidc.js
@@ -1,0 +1,133 @@
+/**
+ * GitHub Actions OIDC token verification.
+ *
+ * Workflows request an ID token (permissions: id-token: write) and present it
+ * as a Bearer token. We verify the RS256 signature against GitHub's published
+ * JWKS, then check issuer, audience, and expiry. The caller inspects the
+ * returned claims (notably `repository`) to authorize the request.
+ *
+ * See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+ */
+
+export const GITHUB_OIDC_ISSUER = 'https://token.actions.githubusercontent.com';
+const JWKS_URL = `${GITHUB_OIDC_ISSUER}/.well-known/jwks`;
+const JWKS_CACHE_TTL_MS = 60 * 60 * 1000;
+// Tolerated clock skew between GitHub and the Worker, in seconds
+const CLOCK_SKEW_S = 60;
+
+let jwksCache = { keys: null, fetchedAt: 0 };
+
+function base64UrlDecode(input) {
+  let base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4 !== 0) {
+    base64 += '=';
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function decodeJsonSegment(segment) {
+  return JSON.parse(new TextDecoder().decode(base64UrlDecode(segment)));
+}
+
+async function getSigningKeys(forceRefresh = false) {
+  const now = Date.now();
+  if (!forceRefresh && jwksCache.keys && now - jwksCache.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return jwksCache.keys;
+  }
+
+  const response = await fetch(JWKS_URL, {
+    headers: { 'Accept': 'application/json' }
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch GitHub JWKS (status ${response.status})`);
+  }
+  const data = await response.json();
+  if (!Array.isArray(data.keys) || data.keys.length === 0) {
+    throw new Error('GitHub JWKS response contained no keys');
+  }
+  jwksCache = { keys: data.keys, fetchedAt: now };
+  return jwksCache.keys;
+}
+
+// Exposed for tests only
+export function resetJwksCache() {
+  jwksCache = { keys: null, fetchedAt: 0 };
+}
+
+/**
+ * Verify a GitHub Actions OIDC token and return its claims.
+ *
+ * @param {string} token - Compact JWT from the workflow's ID token request
+ * @param {string} expectedAudience - Audience the token must carry
+ * @returns {Promise<object>} verified claims
+ * @throws {Error} if the token is malformed, unsigned by GitHub, or its
+ *   issuer/audience/validity window checks fail
+ */
+export async function verifyGitHubActionsToken(token, expectedAudience) {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Malformed JWT');
+  }
+
+  let header, claims;
+  try {
+    header = decodeJsonSegment(parts[0]);
+    claims = decodeJsonSegment(parts[1]);
+  } catch {
+    throw new Error('Malformed JWT');
+  }
+
+  if (header.alg !== 'RS256') {
+    throw new Error(`Unexpected JWT algorithm: ${header.alg}`);
+  }
+
+  let keys = await getSigningKeys();
+  let jwk = keys.find((k) => k.kid === header.kid);
+  if (!jwk) {
+    // Key rotation: refresh the JWKS once before giving up
+    keys = await getSigningKeys(true);
+    jwk = keys.find((k) => k.kid === header.kid);
+  }
+  if (!jwk) {
+    throw new Error('JWT signed with unknown key');
+  }
+
+  const key = await crypto.subtle.importKey(
+    'jwk',
+    { kty: jwk.kty, n: jwk.n, e: jwk.e },
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+
+  const signedData = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+  const signature = base64UrlDecode(parts[2]);
+  const valid = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, signedData);
+  if (!valid) {
+    throw new Error('Invalid JWT signature');
+  }
+
+  if (claims.iss !== GITHUB_OIDC_ISSUER) {
+    throw new Error(`Unexpected JWT issuer: ${claims.iss}`);
+  }
+
+  const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+  if (!audiences.includes(expectedAudience)) {
+    throw new Error('JWT audience mismatch');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof claims.exp !== 'number' || claims.exp <= now - CLOCK_SKEW_S) {
+    throw new Error('JWT has expired');
+  }
+  if (typeof claims.nbf === 'number' && claims.nbf > now + CLOCK_SKEW_S) {
+    throw new Error('JWT not yet valid');
+  }
+
+  return claims;
+}

--- a/image-upload.js
+++ b/image-upload.js
@@ -77,6 +77,78 @@ function serveUrlFor(request, key) {
   return `${new URL(request.url).origin}/i/${key}`;
 }
 
+function hexToBase64(hex) {
+  let binary = '';
+  for (let i = 0; i < hex.length; i += 2) {
+    binary += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16));
+  }
+  return btoa(binary);
+}
+
+/**
+ * Validate an offer payload. Returns { error } on failure, or the validated
+ * { owner, repo, hash, ext, uploadUrl, uploadHeaders, ttl } on success.
+ * Exported for tests.
+ */
+export function validateOfferPayload(body) {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return { error: 'Request body must be a JSON object' };
+  }
+
+  const { owner, repo, hash, ext, upload_url, upload_headers, expires_in } = body;
+
+  const coordError = validateCoordinates(owner, repo, hash, ext);
+  if (coordError) {
+    return { error: coordError };
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(upload_url);
+  } catch {
+    return { error: 'upload_url is not a valid URL' };
+  }
+  if (parsedUrl.protocol !== 'https:' || !parsedUrl.hostname.endsWith(UPLOAD_HOST_SUFFIX)) {
+    return { error: `upload_url must be an https URL on *${UPLOAD_HOST_SUFFIX}` };
+  }
+
+  if (typeof upload_headers !== 'object' || upload_headers === null || Array.isArray(upload_headers)) {
+    return { error: 'upload_headers must be an object' };
+  }
+  const entries = Object.entries(upload_headers);
+  if (entries.length > MAX_UPLOAD_HEADERS) {
+    return { error: 'Too many upload_headers' };
+  }
+  const uploadHeaders = {};
+  for (const [name, value] of entries) {
+    if (!/^[A-Za-z0-9-]+$/.test(name) || typeof value !== 'string') {
+      return { error: `Invalid upload header: ${name}` };
+    }
+    uploadHeaders[name.toLowerCase()] = value;
+  }
+
+  // The security model requires every pre-signed URL to be bound to the
+  // offered content hash: the uploader must send x-amz-checksum-sha256 with
+  // exactly this value, and (because x-amz-* headers must be signed) an URL
+  // that was not signed for it will be rejected by R2. Refuse offers that
+  // don't carry the binding.
+  const expectedChecksum = hexToBase64(hash);
+  if (uploadHeaders['x-amz-checksum-sha256'] !== expectedChecksum) {
+    return { error: 'upload_headers must include x-amz-checksum-sha256 set to the base64 encoding of hash' };
+  }
+
+  let ttl = DEFAULT_OFFER_TTL_S;
+  if (expires_in !== undefined) {
+    const parsed = Number(expires_in);
+    if (!Number.isFinite(parsed)) {
+      return { error: 'expires_in must be a number' };
+    }
+    ttl = Math.min(Math.max(Math.floor(parsed), MIN_OFFER_TTL_S), MAX_OFFER_TTL_S);
+  }
+
+  return { owner, repo, hash, ext, uploadUrl: upload_url, uploadHeaders, ttl };
+}
+
 // Handle POST /image-upload/offer (called by the image-upload workflow)
 export async function handleImageOffer(request, env, body) {
   if (!env.IMAGE_OFFERS) {
@@ -98,12 +170,11 @@ export async function handleImageOffer(request, env, body) {
     return jsonResponse({ error: 'invalid_oidc_token', error_description: error.message }, 401);
   }
 
-  const { owner, repo, hash, ext, upload_url, upload_headers, expires_in } = body;
-
-  const validationError = validateCoordinates(owner, repo, hash, ext);
-  if (validationError) {
-    return jsonResponse({ error: 'invalid_request', error_description: validationError }, 400);
+  const payload = validateOfferPayload(body);
+  if (payload.error) {
+    return jsonResponse({ error: 'invalid_request', error_description: payload.error }, 400);
   }
+  const { owner, repo, hash, ext, uploadUrl, uploadHeaders, ttl } = payload;
 
   // The OIDC token proves which repository's workflow is calling; it must
   // match the coordinates it is offering an upload URL for.
@@ -114,49 +185,10 @@ export async function handleImageOffer(request, env, body) {
     }, 403);
   }
 
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(upload_url);
-  } catch {
-    return jsonResponse({ error: 'invalid_request', error_description: 'upload_url is not a valid URL' }, 400);
-  }
-  if (uploadUrl.protocol !== 'https:' || !uploadUrl.hostname.endsWith(UPLOAD_HOST_SUFFIX)) {
-    return jsonResponse({
-      error: 'invalid_request',
-      error_description: `upload_url must be an https URL on *${UPLOAD_HOST_SUFFIX}`
-    }, 400);
-  }
-
-  const headers = {};
-  if (upload_headers !== undefined) {
-    if (typeof upload_headers !== 'object' || upload_headers === null || Array.isArray(upload_headers)) {
-      return jsonResponse({ error: 'invalid_request', error_description: 'upload_headers must be an object' }, 400);
-    }
-    const entries = Object.entries(upload_headers);
-    if (entries.length > MAX_UPLOAD_HEADERS) {
-      return jsonResponse({ error: 'invalid_request', error_description: 'Too many upload_headers' }, 400);
-    }
-    for (const [name, value] of entries) {
-      if (!/^[A-Za-z0-9-]+$/.test(name) || typeof value !== 'string') {
-        return jsonResponse({ error: 'invalid_request', error_description: `Invalid upload header: ${name}` }, 400);
-      }
-      headers[name.toLowerCase()] = value;
-    }
-  }
-
-  let ttl = DEFAULT_OFFER_TTL_S;
-  if (expires_in !== undefined) {
-    const parsed = Number(expires_in);
-    if (!Number.isFinite(parsed)) {
-      return jsonResponse({ error: 'invalid_request', error_description: 'expires_in must be a number' }, 400);
-    }
-    ttl = Math.min(Math.max(Math.floor(parsed), MIN_OFFER_TTL_S), MAX_OFFER_TTL_S);
-  }
-
   const key = objectKey(owner, repo, hash, ext);
   await env.IMAGE_OFFERS.put(`offer:${key}`, JSON.stringify({
-    upload_url,
-    upload_headers: headers,
+    upload_url: uploadUrl,
+    upload_headers: uploadHeaders,
     created_at: new Date().toISOString(),
     workflow_run_id: claims.run_id
   }), { expirationTtl: ttl });
@@ -180,10 +212,12 @@ export async function handleImageStatus(request, env) {
   const key = objectKey(owner, repo, hash, ext);
   const serveUrl = serveUrlFor(request, key);
 
-  // Already uploaded (content-addressed, so this is also the dedupe path)
+  // Already uploaded (content-addressed, so this is also the dedupe path).
+  // Only counts if the object would actually be served — same checksum rule
+  // as the serve path; a re-upload overwrites an unverifiable object.
   if (env.IMAGES) {
     const head = await env.IMAGES.head(key);
-    if (head) {
+    if (head && hasVerifiedChecksum(head, hash)) {
       return jsonResponse({ status: 'uploaded', serve_url: serveUrl });
     }
   }
@@ -207,6 +241,16 @@ export async function handleImageStatus(request, env) {
 
 function bufferToHex(buffer) {
   return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Content-addressed integrity: an object is only serveable when it carries
+// the SHA-256 checksum R2 recorded at upload time (bound into the pre-signed
+// PUT) and it matches the hash in the key. Objects without a checksum (e.g.
+// written out-of-band without ChecksumSHA256) are refused rather than served
+// unverified — the immutable-URL guarantee depends on this.
+function hasVerifiedChecksum(objectMeta, hash) {
+  const stored = objectMeta.checksums && objectMeta.checksums.sha256;
+  return Boolean(stored) && bufferToHex(stored) === hash;
 }
 
 function serveHeaders(object, ext) {
@@ -245,6 +289,9 @@ export async function handleImageServe(request, env) {
     if (!head) {
       return new Response(null, { status: 404 });
     }
+    if (!hasVerifiedChecksum(head, hash)) {
+      return new Response(null, { status: 409 });
+    }
     return new Response(null, { status: 200, headers: serveHeaders(head, ext) });
   }
 
@@ -253,13 +300,10 @@ export async function handleImageServe(request, env) {
     return jsonResponse({ error: 'not_found' }, 404);
   }
 
-  // Content-addressed integrity: the stored SHA-256 checksum (bound into the
-  // pre-signed PUT) must match the hash in the key, or we refuse to serve.
-  const storedChecksum = object.checksums && object.checksums.sha256;
-  if (storedChecksum && bufferToHex(storedChecksum) !== hash) {
+  if (!hasVerifiedChecksum(object, hash)) {
     return jsonResponse({
       error: 'checksum_mismatch',
-      error_description: 'Stored object does not match its content-addressed key'
+      error_description: 'Stored object does not carry a verified SHA-256 checksum matching its content-addressed key'
     }, 409);
   }
 

--- a/image-upload.js
+++ b/image-upload.js
@@ -4,18 +4,26 @@
  * Flow (see docs/image-upload-design.md):
  *  1. A maintainer runs `gh image <file>`, which dispatches the repo's
  *     image-upload workflow with the file's SHA-256 hash and extension.
- *  2. The workflow pre-signs a checksum-bound R2 PUT URL and registers it
- *     here via POST /image-upload/offer, authenticated with a GitHub
- *     Actions OIDC token whose `repository` claim must match the offer.
+ *     The workflow is committed automatically when the as-a-bot app is
+ *     installed (see app-install.js) and holds no secrets.
+ *  2. The workflow calls POST /image-upload/offer with just {hash, ext},
+ *     authenticated by a GitHub Actions OIDC token. The worker derives
+ *     owner/repo from the token's `repository` claim and mints a
+ *     checksum-bound pre-signed R2 PUT URL itself (r2-presign.js) using
+ *     R2 credentials that live only as Worker secrets.
  *  3. The client polls GET /image-upload/status until the offer appears,
  *     uploads the file to the pre-signed URL, and embeds the serve URL.
  *  4. GET/HEAD /i/{owner}/{repo}/{hash}.{ext} serves the object from R2
- *     with immutable caching.
+ *     with immutable caching. Uploads expire after 90 days; re-uploading
+ *     the same file renews them at the same URL.
  *
  * Bindings: IMAGE_OFFERS (KV, transient offers), IMAGES (R2 bucket).
+ * Secrets: R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY.
+ * Vars: R2_ACCOUNT_ID, R2_BUCKET, IMAGE_OIDC_AUDIENCE.
  */
 
 import { verifyGitHubActionsToken } from './github-oidc.js';
+import { presignR2ImagePut } from './r2-presign.js';
 
 export const IMAGE_CONTENT_TYPES = {
   png: 'image/png',
@@ -34,13 +42,13 @@ const DEFAULT_OIDC_AUDIENCE = 'as-a-bot-images';
 const NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 const HASH_PATTERN = /^[a-f0-9]{64}$/;
 const SERVE_PATH_PATTERN = /^\/i\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/([a-f0-9]{64})\.([a-z0-9]+)$/;
-// Pre-signed URLs must point at R2's S3 endpoint — never accept an
-// arbitrary upload destination from the workflow.
-const UPLOAD_HOST_SUFFIX = '.r2.cloudflarestorage.com';
 const DEFAULT_OFFER_TTL_S = 900;
 const MIN_OFFER_TTL_S = 60; // KV minimum expirationTtl
 const MAX_OFFER_TTL_S = 3600;
-const MAX_UPLOAD_HEADERS = 8;
+// Uploads are kept for 90 days. Enforced here at serve time (expired
+// objects are refused and deleted); pair with an R2 lifecycle rule on the
+// bucket so storage is reclaimed even if an object is never requested.
+export const UPLOAD_TTL_S = 90 * 24 * 60 * 60;
 
 function jsonResponse(body, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(body), {
@@ -60,6 +68,10 @@ function validateCoordinates(owner, repo, hash, ext) {
   if (!repo || !NAME_PATTERN.test(repo)) {
     return 'Invalid or missing repo';
   }
+  return validateHashExt(hash, ext);
+}
+
+function validateHashExt(hash, ext) {
   if (!hash || !HASH_PATTERN.test(hash)) {
     return 'Invalid or missing hash (expected 64 lowercase hex chars)';
   }
@@ -86,8 +98,8 @@ function hexToBase64(hex) {
 }
 
 /**
- * Validate an offer payload. Returns { error } on failure, or the validated
- * { owner, repo, hash, ext, uploadUrl, uploadHeaders, ttl } on success.
+ * Validate an offer payload ({hash, ext, expires_in?}). Returns { error }
+ * on failure, or the validated { hash, ext, ttl } on success.
  * Exported for tests.
  */
 export function validateOfferPayload(body) {
@@ -95,46 +107,11 @@ export function validateOfferPayload(body) {
     return { error: 'Request body must be a JSON object' };
   }
 
-  const { owner, repo, hash, ext, upload_url, upload_headers, expires_in } = body;
+  const { hash, ext, expires_in } = body;
 
-  const coordError = validateCoordinates(owner, repo, hash, ext);
-  if (coordError) {
-    return { error: coordError };
-  }
-
-  let parsedUrl;
-  try {
-    parsedUrl = new URL(upload_url);
-  } catch {
-    return { error: 'upload_url is not a valid URL' };
-  }
-  if (parsedUrl.protocol !== 'https:' || !parsedUrl.hostname.endsWith(UPLOAD_HOST_SUFFIX)) {
-    return { error: `upload_url must be an https URL on *${UPLOAD_HOST_SUFFIX}` };
-  }
-
-  if (typeof upload_headers !== 'object' || upload_headers === null || Array.isArray(upload_headers)) {
-    return { error: 'upload_headers must be an object' };
-  }
-  const entries = Object.entries(upload_headers);
-  if (entries.length > MAX_UPLOAD_HEADERS) {
-    return { error: 'Too many upload_headers' };
-  }
-  const uploadHeaders = {};
-  for (const [name, value] of entries) {
-    if (!/^[A-Za-z0-9-]+$/.test(name) || typeof value !== 'string') {
-      return { error: `Invalid upload header: ${name}` };
-    }
-    uploadHeaders[name.toLowerCase()] = value;
-  }
-
-  // The security model requires every pre-signed URL to be bound to the
-  // offered content hash: the uploader must send x-amz-checksum-sha256 with
-  // exactly this value, and (because x-amz-* headers must be signed) an URL
-  // that was not signed for it will be rejected by R2. Refuse offers that
-  // don't carry the binding.
-  const expectedChecksum = hexToBase64(hash);
-  if (uploadHeaders['x-amz-checksum-sha256'] !== expectedChecksum) {
-    return { error: 'upload_headers must include x-amz-checksum-sha256 set to the base64 encoding of hash' };
+  const hashExtError = validateHashExt(hash, ext);
+  if (hashExtError) {
+    return { error: hashExtError };
   }
 
   let ttl = DEFAULT_OFFER_TTL_S;
@@ -146,13 +123,16 @@ export function validateOfferPayload(body) {
     ttl = Math.min(Math.max(Math.floor(parsed), MIN_OFFER_TTL_S), MAX_OFFER_TTL_S);
   }
 
-  return { owner, repo, hash, ext, uploadUrl: upload_url, uploadHeaders, ttl };
+  return { hash, ext, ttl };
 }
 
 // Handle POST /image-upload/offer (called by the image-upload workflow)
 export async function handleImageOffer(request, env, body) {
   if (!env.IMAGE_OFFERS) {
     return jsonResponse({ error: 'Image upload not configured (IMAGE_OFFERS KV missing)' }, 503);
+  }
+  if (!env.R2_ACCESS_KEY_ID || !env.R2_SECRET_ACCESS_KEY || !env.R2_ACCOUNT_ID || !env.R2_BUCKET) {
+    return jsonResponse({ error: 'Image upload not configured (R2 credentials missing)' }, 503);
   }
 
   const authHeader = request.headers.get('Authorization') || '';
@@ -174,26 +154,62 @@ export async function handleImageOffer(request, env, body) {
   if (payload.error) {
     return jsonResponse({ error: 'invalid_request', error_description: payload.error }, 400);
   }
-  const { owner, repo, hash, ext, uploadUrl, uploadHeaders, ttl } = payload;
+  const { hash, ext, ttl } = payload;
 
-  // The OIDC token proves which repository's workflow is calling; it must
-  // match the coordinates it is offering an upload URL for.
-  if ((claims.repository || '').toLowerCase() !== `${owner}/${repo}`.toLowerCase()) {
+  // The OIDC token is the sole source of truth for which repository is
+  // asking — coordinates cannot be spoofed by the request body.
+  const repository = claims.repository || '';
+  const [owner, repo] = repository.split('/');
+  const coordError = validateCoordinates(owner, repo, hash, ext);
+  if (coordError) {
     return jsonResponse({
-      error: 'repository_mismatch',
-      error_description: `OIDC token was issued for '${claims.repository}', not '${owner}/${repo}'`
+      error: 'invalid_repository_claim',
+      error_description: `OIDC repository claim '${repository}' is not usable: ${coordError}`
     }, 403);
   }
 
+  // Mint the pre-signed PUT URL. The checksum is part of the signature, so
+  // this URL can only ever upload content whose SHA-256 matches `hash`.
   const key = objectKey(owner, repo, hash, ext);
+  const checksumB64 = hexToBase64(hash);
+  const uploadUrl = await presignR2ImagePut(env, key, checksumB64, ttl);
+
   await env.IMAGE_OFFERS.put(`offer:${key}`, JSON.stringify({
     upload_url: uploadUrl,
-    upload_headers: uploadHeaders,
+    upload_headers: { 'x-amz-checksum-sha256': checksumB64 },
     created_at: new Date().toISOString(),
     workflow_run_id: claims.run_id
   }), { expirationTtl: ttl });
 
+  // Only the serve URL goes back to the workflow: the workflow's run logs
+  // are readable by anyone with repo read access, so the pre-signed URL
+  // must never appear there. The client fetches it from /image-upload/status.
   return jsonResponse({ status: 'ready', serve_url: serveUrlFor(request, key) }, 201);
+}
+
+function bufferToHex(buffer) {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Content-addressed integrity: an object is only serveable when it carries
+// the SHA-256 checksum R2 recorded at upload time (bound into the pre-signed
+// PUT) and it matches the hash in the key. Objects without a checksum (e.g.
+// written out-of-band without ChecksumSHA256) are refused rather than served
+// unverified — the immutable-URL guarantee depends on this.
+function hasVerifiedChecksum(objectMeta, hash) {
+  const stored = objectMeta.checksums && objectMeta.checksums.sha256;
+  return Boolean(stored) && bufferToHex(stored) === hash;
+}
+
+function objectAgeSeconds(objectMeta) {
+  if (!objectMeta.uploaded) {
+    return 0;
+  }
+  return (Date.now() - new Date(objectMeta.uploaded).getTime()) / 1000;
+}
+
+function isExpired(objectMeta) {
+  return objectAgeSeconds(objectMeta) > UPLOAD_TTL_S;
 }
 
 // Handle GET /image-upload/status?owner=&repo=&hash=&ext= (polled by gh image)
@@ -213,11 +229,11 @@ export async function handleImageStatus(request, env) {
   const serveUrl = serveUrlFor(request, key);
 
   // Already uploaded (content-addressed, so this is also the dedupe path).
-  // Only counts if the object would actually be served — same checksum rule
-  // as the serve path; a re-upload overwrites an unverifiable object.
+  // Only counts if the object would actually be served — same checksum and
+  // expiry rules as the serve path; a re-upload overwrites and renews it.
   if (env.IMAGES) {
     const head = await env.IMAGES.head(key);
-    if (head && hasVerifiedChecksum(head, hash)) {
+    if (head && hasVerifiedChecksum(head, hash) && !isExpired(head)) {
       return jsonResponse({ status: 'uploaded', serve_url: serveUrl });
     }
   }
@@ -239,25 +255,14 @@ export async function handleImageStatus(request, env) {
   return jsonResponse({ status: 'pending' }, 202);
 }
 
-function bufferToHex(buffer) {
-  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-// Content-addressed integrity: an object is only serveable when it carries
-// the SHA-256 checksum R2 recorded at upload time (bound into the pre-signed
-// PUT) and it matches the hash in the key. Objects without a checksum (e.g.
-// written out-of-band without ChecksumSHA256) are refused rather than served
-// unverified — the immutable-URL guarantee depends on this.
-function hasVerifiedChecksum(objectMeta, hash) {
-  const stored = objectMeta.checksums && objectMeta.checksums.sha256;
-  return Boolean(stored) && bufferToHex(stored) === hash;
-}
-
 function serveHeaders(object, ext) {
+  // Objects are immutable but expire: cap the cache lifetime at whatever
+  // is left of the object's 90 days.
+  const remaining = Math.max(0, Math.floor(UPLOAD_TTL_S - objectAgeSeconds(object)));
   const headers = {
     'Content-Type': IMAGE_CONTENT_TYPES[ext] || 'application/octet-stream',
     'Content-Length': String(object.size),
-    'Cache-Control': 'public, max-age=31536000, immutable',
+    'Cache-Control': `public, max-age=${remaining}, immutable`,
     // Defense against active content (mainly SVG): never sniff, never execute
     'X-Content-Type-Options': 'nosniff',
     'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'"
@@ -289,6 +294,10 @@ export async function handleImageServe(request, env) {
     if (!head) {
       return new Response(null, { status: 404 });
     }
+    if (isExpired(head)) {
+      await env.IMAGES.delete(key);
+      return new Response(null, { status: 410 });
+    }
     if (!hasVerifiedChecksum(head, hash)) {
       return new Response(null, { status: 409 });
     }
@@ -298,6 +307,14 @@ export async function handleImageServe(request, env) {
   const object = await env.IMAGES.get(key);
   if (!object) {
     return jsonResponse({ error: 'not_found' }, 404);
+  }
+
+  if (isExpired(object)) {
+    await env.IMAGES.delete(key);
+    return jsonResponse({
+      error: 'expired',
+      error_description: `Uploads are kept for ${UPLOAD_TTL_S / 86400} days; re-run gh image to renew this file at the same URL`
+    }, 410);
   }
 
   if (!hasVerifiedChecksum(object, hash)) {

--- a/image-upload.js
+++ b/image-upload.js
@@ -1,0 +1,267 @@
+/**
+ * Image/video upload brokering for `gh image`.
+ *
+ * Flow (see docs/image-upload-design.md):
+ *  1. A maintainer runs `gh image <file>`, which dispatches the repo's
+ *     image-upload workflow with the file's SHA-256 hash and extension.
+ *  2. The workflow pre-signs a checksum-bound R2 PUT URL and registers it
+ *     here via POST /image-upload/offer, authenticated with a GitHub
+ *     Actions OIDC token whose `repository` claim must match the offer.
+ *  3. The client polls GET /image-upload/status until the offer appears,
+ *     uploads the file to the pre-signed URL, and embeds the serve URL.
+ *  4. GET/HEAD /i/{owner}/{repo}/{hash}.{ext} serves the object from R2
+ *     with immutable caching.
+ *
+ * Bindings: IMAGE_OFFERS (KV, transient offers), IMAGES (R2 bucket).
+ */
+
+import { verifyGitHubActionsToken } from './github-oidc.js';
+
+export const IMAGE_CONTENT_TYPES = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  avif: 'image/avif',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  webm: 'video/webm'
+};
+
+const DEFAULT_OIDC_AUDIENCE = 'as-a-bot-images';
+const NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+const SERVE_PATH_PATTERN = /^\/i\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/([a-f0-9]{64})\.([a-z0-9]+)$/;
+// Pre-signed URLs must point at R2's S3 endpoint — never accept an
+// arbitrary upload destination from the workflow.
+const UPLOAD_HOST_SUFFIX = '.r2.cloudflarestorage.com';
+const DEFAULT_OFFER_TTL_S = 900;
+const MIN_OFFER_TTL_S = 60; // KV minimum expirationTtl
+const MAX_OFFER_TTL_S = 3600;
+const MAX_UPLOAD_HEADERS = 8;
+
+function jsonResponse(body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      ...extraHeaders
+    }
+  });
+}
+
+function validateCoordinates(owner, repo, hash, ext) {
+  if (!owner || !NAME_PATTERN.test(owner)) {
+    return 'Invalid or missing owner';
+  }
+  if (!repo || !NAME_PATTERN.test(repo)) {
+    return 'Invalid or missing repo';
+  }
+  if (!hash || !HASH_PATTERN.test(hash)) {
+    return 'Invalid or missing hash (expected 64 lowercase hex chars)';
+  }
+  if (!ext || !Object.prototype.hasOwnProperty.call(IMAGE_CONTENT_TYPES, ext)) {
+    return `Invalid or missing ext (allowed: ${Object.keys(IMAGE_CONTENT_TYPES).join(', ')})`;
+  }
+  return null;
+}
+
+function objectKey(owner, repo, hash, ext) {
+  return `${owner}/${repo}/${hash}.${ext}`;
+}
+
+function serveUrlFor(request, key) {
+  return `${new URL(request.url).origin}/i/${key}`;
+}
+
+// Handle POST /image-upload/offer (called by the image-upload workflow)
+export async function handleImageOffer(request, env, body) {
+  if (!env.IMAGE_OFFERS) {
+    return jsonResponse({ error: 'Image upload not configured (IMAGE_OFFERS KV missing)' }, 503);
+  }
+
+  const authHeader = request.headers.get('Authorization') || '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return jsonResponse({ error: 'unauthorized', error_description: 'Missing Bearer token' }, 401);
+  }
+
+  let claims;
+  try {
+    claims = await verifyGitHubActionsToken(
+      authHeader.slice('Bearer '.length).trim(),
+      env.IMAGE_OIDC_AUDIENCE || DEFAULT_OIDC_AUDIENCE
+    );
+  } catch (error) {
+    return jsonResponse({ error: 'invalid_oidc_token', error_description: error.message }, 401);
+  }
+
+  const { owner, repo, hash, ext, upload_url, upload_headers, expires_in } = body;
+
+  const validationError = validateCoordinates(owner, repo, hash, ext);
+  if (validationError) {
+    return jsonResponse({ error: 'invalid_request', error_description: validationError }, 400);
+  }
+
+  // The OIDC token proves which repository's workflow is calling; it must
+  // match the coordinates it is offering an upload URL for.
+  if ((claims.repository || '').toLowerCase() !== `${owner}/${repo}`.toLowerCase()) {
+    return jsonResponse({
+      error: 'repository_mismatch',
+      error_description: `OIDC token was issued for '${claims.repository}', not '${owner}/${repo}'`
+    }, 403);
+  }
+
+  let uploadUrl;
+  try {
+    uploadUrl = new URL(upload_url);
+  } catch {
+    return jsonResponse({ error: 'invalid_request', error_description: 'upload_url is not a valid URL' }, 400);
+  }
+  if (uploadUrl.protocol !== 'https:' || !uploadUrl.hostname.endsWith(UPLOAD_HOST_SUFFIX)) {
+    return jsonResponse({
+      error: 'invalid_request',
+      error_description: `upload_url must be an https URL on *${UPLOAD_HOST_SUFFIX}`
+    }, 400);
+  }
+
+  const headers = {};
+  if (upload_headers !== undefined) {
+    if (typeof upload_headers !== 'object' || upload_headers === null || Array.isArray(upload_headers)) {
+      return jsonResponse({ error: 'invalid_request', error_description: 'upload_headers must be an object' }, 400);
+    }
+    const entries = Object.entries(upload_headers);
+    if (entries.length > MAX_UPLOAD_HEADERS) {
+      return jsonResponse({ error: 'invalid_request', error_description: 'Too many upload_headers' }, 400);
+    }
+    for (const [name, value] of entries) {
+      if (!/^[A-Za-z0-9-]+$/.test(name) || typeof value !== 'string') {
+        return jsonResponse({ error: 'invalid_request', error_description: `Invalid upload header: ${name}` }, 400);
+      }
+      headers[name.toLowerCase()] = value;
+    }
+  }
+
+  let ttl = DEFAULT_OFFER_TTL_S;
+  if (expires_in !== undefined) {
+    const parsed = Number(expires_in);
+    if (!Number.isFinite(parsed)) {
+      return jsonResponse({ error: 'invalid_request', error_description: 'expires_in must be a number' }, 400);
+    }
+    ttl = Math.min(Math.max(Math.floor(parsed), MIN_OFFER_TTL_S), MAX_OFFER_TTL_S);
+  }
+
+  const key = objectKey(owner, repo, hash, ext);
+  await env.IMAGE_OFFERS.put(`offer:${key}`, JSON.stringify({
+    upload_url,
+    upload_headers: headers,
+    created_at: new Date().toISOString(),
+    workflow_run_id: claims.run_id
+  }), { expirationTtl: ttl });
+
+  return jsonResponse({ status: 'ready', serve_url: serveUrlFor(request, key) }, 201);
+}
+
+// Handle GET /image-upload/status?owner=&repo=&hash=&ext= (polled by gh image)
+export async function handleImageStatus(request, env) {
+  const url = new URL(request.url);
+  const owner = url.searchParams.get('owner');
+  const repo = url.searchParams.get('repo');
+  const hash = url.searchParams.get('hash');
+  const ext = url.searchParams.get('ext');
+
+  const validationError = validateCoordinates(owner, repo, hash, ext);
+  if (validationError) {
+    return jsonResponse({ error: 'invalid_request', error_description: validationError }, 400);
+  }
+
+  const key = objectKey(owner, repo, hash, ext);
+  const serveUrl = serveUrlFor(request, key);
+
+  // Already uploaded (content-addressed, so this is also the dedupe path)
+  if (env.IMAGES) {
+    const head = await env.IMAGES.head(key);
+    if (head) {
+      return jsonResponse({ status: 'uploaded', serve_url: serveUrl });
+    }
+  }
+
+  if (!env.IMAGE_OFFERS) {
+    return jsonResponse({ error: 'Image upload not configured (IMAGE_OFFERS KV missing)' }, 503);
+  }
+
+  const offer = await env.IMAGE_OFFERS.get(`offer:${key}`, 'json');
+  if (offer) {
+    return jsonResponse({
+      status: 'ready',
+      upload_url: offer.upload_url,
+      upload_headers: offer.upload_headers || {},
+      serve_url: serveUrl
+    });
+  }
+
+  return jsonResponse({ status: 'pending' }, 202);
+}
+
+function bufferToHex(buffer) {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function serveHeaders(object, ext) {
+  const headers = {
+    'Content-Type': IMAGE_CONTENT_TYPES[ext] || 'application/octet-stream',
+    'Content-Length': String(object.size),
+    'Cache-Control': 'public, max-age=31536000, immutable',
+    // Defense against active content (mainly SVG): never sniff, never execute
+    'X-Content-Type-Options': 'nosniff',
+    'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'"
+  };
+  if (object.httpEtag) {
+    headers['ETag'] = object.httpEtag;
+  }
+  return headers;
+}
+
+// Handle GET/HEAD /i/{owner}/{repo}/{hash}.{ext}
+export async function handleImageServe(request, env) {
+  if (!env.IMAGES) {
+    return jsonResponse({ error: 'Image serving not configured (IMAGES R2 binding missing)' }, 503);
+  }
+
+  const match = new URL(request.url).pathname.match(SERVE_PATH_PATTERN);
+  if (!match) {
+    return jsonResponse({ error: 'not_found' }, 404);
+  }
+  const [, owner, repo, hash, ext] = match;
+  if (!Object.prototype.hasOwnProperty.call(IMAGE_CONTENT_TYPES, ext)) {
+    return jsonResponse({ error: 'not_found' }, 404);
+  }
+  const key = objectKey(owner, repo, hash, ext);
+
+  if (request.method === 'HEAD') {
+    const head = await env.IMAGES.head(key);
+    if (!head) {
+      return new Response(null, { status: 404 });
+    }
+    return new Response(null, { status: 200, headers: serveHeaders(head, ext) });
+  }
+
+  const object = await env.IMAGES.get(key);
+  if (!object) {
+    return jsonResponse({ error: 'not_found' }, 404);
+  }
+
+  // Content-addressed integrity: the stored SHA-256 checksum (bound into the
+  // pre-signed PUT) must match the hash in the key, or we refuse to serve.
+  const storedChecksum = object.checksums && object.checksums.sha256;
+  if (storedChecksum && bufferToHex(storedChecksum) !== hash) {
+    return jsonResponse({
+      error: 'checksum_mismatch',
+      error_description: 'Stored object does not match its content-addressed key'
+    }, 409);
+  }
+
+  return new Response(object.body, { status: 200, headers: serveHeaders(object, ext) });
+}

--- a/image-upload.test.js
+++ b/image-upload.test.js
@@ -1,11 +1,12 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { handleImageOffer, handleImageStatus, handleImageServe, IMAGE_CONTENT_TYPES } from './image-upload.js';
+import { handleImageOffer, handleImageStatus, handleImageServe, validateOfferPayload, IMAGE_CONTENT_TYPES } from './image-upload.js';
 
 // Node 18+ provides Request/Response/Headers/URL natively — no polyfills needed.
 
 const HASH = 'a'.repeat(64);
+const HASH_B64 = Buffer.from(HASH, 'hex').toString('base64');
 
 function makeKV(initial = {}) {
   const store = new Map(Object.entries(initial));
@@ -114,14 +115,74 @@ describe('handleImageStatus', () => {
     assert.equal(body.serve_url, `https://worker.example/i/octo/demo/${HASH}.png`);
   });
 
-  test('reports uploaded when the object already exists in R2', async () => {
-    const r2 = makeR2({ [`octo/demo/${HASH}.png`]: { size: 3, body: 'abc' } });
+  test('reports uploaded when a checksum-verified object exists in R2', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: { size: 3, body: 'abc', checksums: { sha256: hexToBuffer(HASH) } }
+    });
     const request = new Request(`${baseUrl}?${params}`);
     const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: r2 });
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.status, 'uploaded');
     assert.equal(body.serve_url, `https://worker.example/i/octo/demo/${HASH}.png`);
+  });
+
+  test('does not report uploaded for objects without a verifiable checksum', async () => {
+    const r2 = makeR2({ [`octo/demo/${HASH}.png`]: { size: 3, body: 'abc' } });
+    const request = new Request(`${baseUrl}?${params}`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: r2 });
+    assert.equal(response.status, 202);
+    const body = await response.json();
+    assert.equal(body.status, 'pending');
+  });
+});
+
+describe('validateOfferPayload', () => {
+  const validPayload = () => ({
+    owner: 'octo',
+    repo: 'demo',
+    hash: HASH,
+    ext: 'png',
+    upload_url: `https://acc.r2.cloudflarestorage.com/bucket/octo/demo/${HASH}.png?sig=1`,
+    upload_headers: { 'x-amz-checksum-sha256': HASH_B64 },
+    expires_in: 900
+  });
+
+  test('accepts a valid payload', () => {
+    const result = validateOfferPayload(validPayload());
+    assert.equal(result.error, undefined);
+    assert.equal(result.owner, 'octo');
+    assert.equal(result.ttl, 900);
+    assert.equal(result.uploadHeaders['x-amz-checksum-sha256'], HASH_B64);
+  });
+
+  test('rejects non-object bodies', () => {
+    assert.ok(validateOfferPayload(null).error);
+    assert.ok(validateOfferPayload([]).error);
+    assert.ok(validateOfferPayload('str').error);
+  });
+
+  test('rejects upload URLs outside R2', () => {
+    const payload = { ...validPayload(), upload_url: 'https://evil.example/steal' };
+    assert.match(validateOfferPayload(payload).error, /upload_url/);
+  });
+
+  test('rejects offers without the checksum binding header', () => {
+    const payload = { ...validPayload(), upload_headers: {} };
+    assert.match(validateOfferPayload(payload).error, /x-amz-checksum-sha256/);
+  });
+
+  test('rejects offers whose checksum header does not match the hash', () => {
+    const payload = {
+      ...validPayload(),
+      upload_headers: { 'x-amz-checksum-sha256': Buffer.from('b'.repeat(64), 'hex').toString('base64') }
+    };
+    assert.match(validateOfferPayload(payload).error, /x-amz-checksum-sha256/);
+  });
+
+  test('clamps expires_in into the allowed TTL range', () => {
+    assert.equal(validateOfferPayload({ ...validPayload(), expires_in: 5 }).ttl, 60);
+    assert.equal(validateOfferPayload({ ...validPayload(), expires_in: 99999 }).ttl, 3600);
   });
 });
 
@@ -170,13 +231,36 @@ describe('handleImageServe', () => {
     assert.equal(body.error, 'checksum_mismatch');
   });
 
+  test('refuses to serve objects without a stored checksum', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: { body: 'unverified', size: 10 }
+    });
+    const response = await handleImageServe(new Request(serveUrl), { IMAGES: r2 });
+    assert.equal(response.status, 409);
+    const body = await response.json();
+    assert.equal(body.error, 'checksum_mismatch');
+  });
+
   test('answers HEAD without a body', async () => {
     const r2 = makeR2({
-      [`octo/demo/${HASH}.png`]: { body: 'imagebytes', size: 10, httpEtag: '"etag"' }
+      [`octo/demo/${HASH}.png`]: {
+        body: 'imagebytes',
+        size: 10,
+        httpEtag: '"etag"',
+        checksums: { sha256: hexToBuffer(HASH) }
+      }
     });
     const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: r2 });
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('Content-Length'), '10');
+  });
+
+  test('HEAD refuses unverifiable objects', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: { body: 'unverified', size: 10 }
+    });
+    const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: r2 });
+    assert.equal(response.status, 409);
   });
 
   test('HEAD 404s on missing objects', async () => {

--- a/image-upload.test.js
+++ b/image-upload.test.js
@@ -1,0 +1,195 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { handleImageOffer, handleImageStatus, handleImageServe, IMAGE_CONTENT_TYPES } from './image-upload.js';
+
+// Node 18+ provides Request/Response/Headers/URL natively — no polyfills needed.
+
+const HASH = 'a'.repeat(64);
+
+function makeKV(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    async get(key, type) {
+      const value = store.get(key);
+      if (value === undefined) return null;
+      return type === 'json' ? JSON.parse(value) : value;
+    },
+    async put(key, value, options) {
+      store.set(key, value);
+      this.lastPutOptions = options;
+    }
+  };
+}
+
+function makeR2(objects = {}) {
+  return {
+    objects,
+    async head(key) {
+      const obj = objects[key];
+      return obj ? { size: obj.size, httpEtag: obj.httpEtag, checksums: obj.checksums } : null;
+    },
+    async get(key) {
+      const obj = objects[key];
+      return obj
+        ? { body: obj.body, size: obj.size, httpEtag: obj.httpEtag, checksums: obj.checksums }
+        : null;
+    }
+  };
+}
+
+function hexToBuffer(hex) {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+describe('handleImageOffer', () => {
+  test('rejects requests without a Bearer token', async () => {
+    const request = new Request('https://worker.example/image-upload/offer', { method: 'POST' });
+    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV() }, {});
+    assert.equal(response.status, 401);
+    const body = await response.json();
+    assert.equal(body.error, 'unauthorized');
+  });
+
+  test('rejects malformed OIDC tokens', async () => {
+    const request = new Request('https://worker.example/image-upload/offer', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer not-a-jwt' }
+    });
+    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV() }, {});
+    assert.equal(response.status, 401);
+    const body = await response.json();
+    assert.equal(body.error, 'invalid_oidc_token');
+  });
+
+  test('returns 503 when the KV binding is missing', async () => {
+    const request = new Request('https://worker.example/image-upload/offer', { method: 'POST' });
+    const response = await handleImageOffer(request, {}, {});
+    assert.equal(response.status, 503);
+  });
+});
+
+describe('handleImageStatus', () => {
+  const baseUrl = 'https://worker.example/image-upload/status';
+  const params = `owner=octo&repo=demo&hash=${HASH}&ext=png`;
+
+  test('validates coordinates', async () => {
+    const request = new Request(`${baseUrl}?owner=octo&repo=demo&hash=nope&ext=png`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: makeR2() });
+    assert.equal(response.status, 400);
+  });
+
+  test('rejects disallowed extensions', async () => {
+    const request = new Request(`${baseUrl}?owner=octo&repo=demo&hash=${HASH}&ext=exe`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: makeR2() });
+    assert.equal(response.status, 400);
+  });
+
+  test('returns pending when no offer exists', async () => {
+    const request = new Request(`${baseUrl}?${params}`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: makeR2() });
+    assert.equal(response.status, 202);
+    const body = await response.json();
+    assert.equal(body.status, 'pending');
+  });
+
+  test('returns the offer when one is registered', async () => {
+    const offer = {
+      upload_url: 'https://acc.r2.cloudflarestorage.com/bucket/octo/demo/x.png?sig=1',
+      upload_headers: { 'x-amz-checksum-sha256': 'abc=' }
+    };
+    const kv = makeKV({ [`offer:octo/demo/${HASH}.png`]: JSON.stringify(offer) });
+    const request = new Request(`${baseUrl}?${params}`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: kv, IMAGES: makeR2() });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.status, 'ready');
+    assert.equal(body.upload_url, offer.upload_url);
+    assert.deepEqual(body.upload_headers, offer.upload_headers);
+    assert.equal(body.serve_url, `https://worker.example/i/octo/demo/${HASH}.png`);
+  });
+
+  test('reports uploaded when the object already exists in R2', async () => {
+    const r2 = makeR2({ [`octo/demo/${HASH}.png`]: { size: 3, body: 'abc' } });
+    const request = new Request(`${baseUrl}?${params}`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: r2 });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.status, 'uploaded');
+    assert.equal(body.serve_url, `https://worker.example/i/octo/demo/${HASH}.png`);
+  });
+});
+
+describe('handleImageServe', () => {
+  const serveUrl = `https://worker.example/i/octo/demo/${HASH}.png`;
+
+  test('404s on malformed paths', async () => {
+    const request = new Request('https://worker.example/i/octo/demo/short.png');
+    const response = await handleImageServe(request, { IMAGES: makeR2() });
+    assert.equal(response.status, 404);
+  });
+
+  test('404s on missing objects', async () => {
+    const response = await handleImageServe(new Request(serveUrl), { IMAGES: makeR2() });
+    assert.equal(response.status, 404);
+  });
+
+  test('serves objects with immutable caching and the right content type', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        body: 'imagebytes',
+        size: 10,
+        httpEtag: '"etag"',
+        checksums: { sha256: hexToBuffer(HASH) }
+      }
+    });
+    const response = await handleImageServe(new Request(serveUrl), { IMAGES: r2 });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('Content-Type'), 'image/png');
+    assert.equal(response.headers.get('Cache-Control'), 'public, max-age=31536000, immutable');
+    assert.equal(response.headers.get('X-Content-Type-Options'), 'nosniff');
+    assert.equal(await response.text(), 'imagebytes');
+  });
+
+  test('refuses to serve objects whose checksum does not match the key', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        body: 'tampered',
+        size: 8,
+        checksums: { sha256: hexToBuffer('b'.repeat(64)) }
+      }
+    });
+    const response = await handleImageServe(new Request(serveUrl), { IMAGES: r2 });
+    assert.equal(response.status, 409);
+    const body = await response.json();
+    assert.equal(body.error, 'checksum_mismatch');
+  });
+
+  test('answers HEAD without a body', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: { body: 'imagebytes', size: 10, httpEtag: '"etag"' }
+    });
+    const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: r2 });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('Content-Length'), '10');
+  });
+
+  test('HEAD 404s on missing objects', async () => {
+    const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: makeR2() });
+    assert.equal(response.status, 404);
+  });
+});
+
+describe('IMAGE_CONTENT_TYPES', () => {
+  test('covers the documented allowlist', () => {
+    assert.deepEqual(
+      Object.keys(IMAGE_CONTENT_TYPES).sort(),
+      ['avif', 'gif', 'jpeg', 'jpg', 'mov', 'mp4', 'png', 'svg', 'webm', 'webp'].sort()
+    );
+  });
+});

--- a/image-upload.test.js
+++ b/image-upload.test.js
@@ -1,12 +1,20 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { handleImageOffer, handleImageStatus, handleImageServe, validateOfferPayload, IMAGE_CONTENT_TYPES } from './image-upload.js';
+import {
+  handleImageOffer,
+  handleImageStatus,
+  handleImageServe,
+  validateOfferPayload,
+  IMAGE_CONTENT_TYPES,
+  UPLOAD_TTL_S
+} from './image-upload.js';
 
 // Node 18+ provides Request/Response/Headers/URL natively — no polyfills needed.
 
 const HASH = 'a'.repeat(64);
-const HASH_B64 = Buffer.from(HASH, 'hex').toString('base64');
+const NOW = Date.now();
+const EXPIRED_UPLOAD_DATE = new Date(NOW - (UPLOAD_TTL_S + 3600) * 1000);
 
 function makeKV(initial = {}) {
   const store = new Map(Object.entries(initial));
@@ -27,15 +35,22 @@ function makeKV(initial = {}) {
 function makeR2(objects = {}) {
   return {
     objects,
+    deleted: [],
     async head(key) {
       const obj = objects[key];
-      return obj ? { size: obj.size, httpEtag: obj.httpEtag, checksums: obj.checksums } : null;
+      return obj
+        ? { size: obj.size, httpEtag: obj.httpEtag, checksums: obj.checksums, uploaded: obj.uploaded }
+        : null;
     },
     async get(key) {
       const obj = objects[key];
       return obj
-        ? { body: obj.body, size: obj.size, httpEtag: obj.httpEtag, checksums: obj.checksums }
+        ? { body: obj.body, size: obj.size, httpEtag: obj.httpEtag, checksums: obj.checksums, uploaded: obj.uploaded }
         : null;
+    },
+    async delete(key) {
+      this.deleted.push(key);
+      delete objects[key];
     }
   };
 }
@@ -48,10 +63,17 @@ function hexToBuffer(hex) {
   return bytes.buffer;
 }
 
+const R2_ENV = {
+  R2_ACCOUNT_ID: 'acct123',
+  R2_BUCKET: 'as-a-bot-images',
+  R2_ACCESS_KEY_ID: 'key',
+  R2_SECRET_ACCESS_KEY: 'secret'
+};
+
 describe('handleImageOffer', () => {
   test('rejects requests without a Bearer token', async () => {
     const request = new Request('https://worker.example/image-upload/offer', { method: 'POST' });
-    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV() }, {});
+    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV(), ...R2_ENV }, {});
     assert.equal(response.status, 401);
     const body = await response.json();
     assert.equal(body.error, 'unauthorized');
@@ -62,7 +84,7 @@ describe('handleImageOffer', () => {
       method: 'POST',
       headers: { Authorization: 'Bearer not-a-jwt' }
     });
-    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV() }, {});
+    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV(), ...R2_ENV }, {});
     assert.equal(response.status, 401);
     const body = await response.json();
     assert.equal(body.error, 'invalid_oidc_token');
@@ -70,8 +92,44 @@ describe('handleImageOffer', () => {
 
   test('returns 503 when the KV binding is missing', async () => {
     const request = new Request('https://worker.example/image-upload/offer', { method: 'POST' });
-    const response = await handleImageOffer(request, {}, {});
+    const response = await handleImageOffer(request, { ...R2_ENV }, {});
     assert.equal(response.status, 503);
+  });
+
+  test('returns 503 when R2 credentials are missing', async () => {
+    const request = new Request('https://worker.example/image-upload/offer', { method: 'POST' });
+    const response = await handleImageOffer(request, { IMAGE_OFFERS: makeKV() }, {});
+    assert.equal(response.status, 503);
+    const body = await response.json();
+    assert.match(body.error, /R2 credentials/);
+  });
+});
+
+describe('validateOfferPayload', () => {
+  test('accepts a valid payload', () => {
+    const result = validateOfferPayload({ hash: HASH, ext: 'png', expires_in: 900 });
+    assert.equal(result.error, undefined);
+    assert.equal(result.hash, HASH);
+    assert.equal(result.ext, 'png');
+    assert.equal(result.ttl, 900);
+  });
+
+  test('rejects non-object bodies', () => {
+    assert.ok(validateOfferPayload(null).error);
+    assert.ok(validateOfferPayload([]).error);
+    assert.ok(validateOfferPayload('str').error);
+  });
+
+  test('rejects bad hashes and extensions', () => {
+    assert.match(validateOfferPayload({ hash: 'short', ext: 'png' }).error, /hash/);
+    assert.match(validateOfferPayload({ hash: HASH.toUpperCase(), ext: 'png' }).error, /hash/);
+    assert.match(validateOfferPayload({ hash: HASH, ext: 'exe' }).error, /ext/);
+  });
+
+  test('clamps expires_in into the allowed TTL range', () => {
+    assert.equal(validateOfferPayload({ hash: HASH, ext: 'png', expires_in: 5 }).ttl, 60);
+    assert.equal(validateOfferPayload({ hash: HASH, ext: 'png', expires_in: 99999 }).ttl, 3600);
+    assert.ok(validateOfferPayload({ hash: HASH, ext: 'png', expires_in: 'soon' }).error);
   });
 });
 
@@ -135,54 +193,19 @@ describe('handleImageStatus', () => {
     const body = await response.json();
     assert.equal(body.status, 'pending');
   });
-});
 
-describe('validateOfferPayload', () => {
-  const validPayload = () => ({
-    owner: 'octo',
-    repo: 'demo',
-    hash: HASH,
-    ext: 'png',
-    upload_url: `https://acc.r2.cloudflarestorage.com/bucket/octo/demo/${HASH}.png?sig=1`,
-    upload_headers: { 'x-amz-checksum-sha256': HASH_B64 },
-    expires_in: 900
-  });
-
-  test('accepts a valid payload', () => {
-    const result = validateOfferPayload(validPayload());
-    assert.equal(result.error, undefined);
-    assert.equal(result.owner, 'octo');
-    assert.equal(result.ttl, 900);
-    assert.equal(result.uploadHeaders['x-amz-checksum-sha256'], HASH_B64);
-  });
-
-  test('rejects non-object bodies', () => {
-    assert.ok(validateOfferPayload(null).error);
-    assert.ok(validateOfferPayload([]).error);
-    assert.ok(validateOfferPayload('str').error);
-  });
-
-  test('rejects upload URLs outside R2', () => {
-    const payload = { ...validPayload(), upload_url: 'https://evil.example/steal' };
-    assert.match(validateOfferPayload(payload).error, /upload_url/);
-  });
-
-  test('rejects offers without the checksum binding header', () => {
-    const payload = { ...validPayload(), upload_headers: {} };
-    assert.match(validateOfferPayload(payload).error, /x-amz-checksum-sha256/);
-  });
-
-  test('rejects offers whose checksum header does not match the hash', () => {
-    const payload = {
-      ...validPayload(),
-      upload_headers: { 'x-amz-checksum-sha256': Buffer.from('b'.repeat(64), 'hex').toString('base64') }
-    };
-    assert.match(validateOfferPayload(payload).error, /x-amz-checksum-sha256/);
-  });
-
-  test('clamps expires_in into the allowed TTL range', () => {
-    assert.equal(validateOfferPayload({ ...validPayload(), expires_in: 5 }).ttl, 60);
-    assert.equal(validateOfferPayload({ ...validPayload(), expires_in: 99999 }).ttl, 3600);
+  test('does not report uploaded for expired objects', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        size: 3,
+        body: 'abc',
+        checksums: { sha256: hexToBuffer(HASH) },
+        uploaded: EXPIRED_UPLOAD_DATE
+      }
+    });
+    const request = new Request(`${baseUrl}?${params}`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: r2 });
+    assert.equal(response.status, 202);
   });
 });
 
@@ -200,19 +223,23 @@ describe('handleImageServe', () => {
     assert.equal(response.status, 404);
   });
 
-  test('serves objects with immutable caching and the right content type', async () => {
+  test('serves objects with capped immutable caching and the right content type', async () => {
     const r2 = makeR2({
       [`octo/demo/${HASH}.png`]: {
         body: 'imagebytes',
         size: 10,
         httpEtag: '"etag"',
-        checksums: { sha256: hexToBuffer(HASH) }
+        checksums: { sha256: hexToBuffer(HASH) },
+        uploaded: new Date(NOW - 3600 * 1000)
       }
     });
     const response = await handleImageServe(new Request(serveUrl), { IMAGES: r2 });
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('Content-Type'), 'image/png');
-    assert.equal(response.headers.get('Cache-Control'), 'public, max-age=31536000, immutable');
+    const cacheControl = response.headers.get('Cache-Control');
+    assert.match(cacheControl, /^public, max-age=\d+, immutable$/);
+    const maxAge = Number(cacheControl.match(/max-age=(\d+)/)[1]);
+    assert.ok(maxAge <= UPLOAD_TTL_S - 3500, `max-age ${maxAge} should be capped below the remaining TTL`);
     assert.equal(response.headers.get('X-Content-Type-Options'), 'nosniff');
     assert.equal(await response.text(), 'imagebytes');
   });
@@ -241,6 +268,22 @@ describe('handleImageServe', () => {
     assert.equal(body.error, 'checksum_mismatch');
   });
 
+  test('deletes and refuses objects older than the 90-day TTL', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        body: 'old',
+        size: 3,
+        checksums: { sha256: hexToBuffer(HASH) },
+        uploaded: EXPIRED_UPLOAD_DATE
+      }
+    });
+    const response = await handleImageServe(new Request(serveUrl), { IMAGES: r2 });
+    assert.equal(response.status, 410);
+    const body = await response.json();
+    assert.equal(body.error, 'expired');
+    assert.deepEqual(r2.deleted, [`octo/demo/${HASH}.png`]);
+  });
+
   test('answers HEAD without a body', async () => {
     const r2 = makeR2({
       [`octo/demo/${HASH}.png`]: {
@@ -261,6 +304,20 @@ describe('handleImageServe', () => {
     });
     const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: r2 });
     assert.equal(response.status, 409);
+  });
+
+  test('HEAD expires old objects', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        body: 'old',
+        size: 3,
+        checksums: { sha256: hexToBuffer(HASH) },
+        uploaded: EXPIRED_UPLOAD_DATE
+      }
+    });
+    const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: r2 });
+    assert.equal(response.status, 410);
+    assert.deepEqual(r2.deleted, [`octo/demo/${HASH}.png`]);
   });
 
   test('HEAD 404s on missing objects', async () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test worker.test.js"
+    "test": "node --test worker.test.js image-upload.test.js"
   },
   "keywords": [
     "github",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test worker.test.js image-upload.test.js"
+    "test": "node --test worker.test.js image-upload.test.js r2-presign.test.js app-install.test.js"
   },
   "keywords": [
     "github",

--- a/r2-presign.js
+++ b/r2-presign.js
@@ -1,0 +1,145 @@
+/**
+ * AWS Signature Version 4 query-string presigning, implemented with
+ * WebCrypto and no dependencies. Used to mint pre-signed R2 PUT URLs so
+ * that R2 credentials only ever live as Worker secrets — participating
+ * repositories need no secrets at all.
+ *
+ * Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+ */
+
+const encoder = new TextEncoder();
+
+function rfc3986Encode(value) {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase()
+  );
+}
+
+function bufferToHex(buffer) {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha256Hex(data) {
+  return bufferToHex(await crypto.subtle.digest('SHA-256', encoder.encode(data)));
+}
+
+async function hmac(keyData, data) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  return crypto.subtle.sign('HMAC', key, encoder.encode(data));
+}
+
+function toAmzDate(date) {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+}
+
+function canonicalizePath(path) {
+  return path.split('/').map(rfc3986Encode).join('/');
+}
+
+/**
+ * Generate a SigV4 pre-signed URL.
+ *
+ * @param {object} options
+ * @param {string} options.method - HTTP method the URL is valid for
+ * @param {string} options.host - Request host
+ * @param {string} options.path - Absolute path (starting with '/')
+ * @param {string} options.region - Signing region (R2 uses 'auto')
+ * @param {string} [options.service] - Signing service (default 's3')
+ * @param {string} options.accessKeyId
+ * @param {string} options.secretAccessKey
+ * @param {number} options.expiresIn - Validity in seconds
+ * @param {object} [options.headers] - Extra headers the requester MUST send;
+ *   they become part of the signature (host is always included)
+ * @param {Date} [options.date] - Signing time (defaults to now; injectable for tests)
+ * @returns {Promise<string>} the pre-signed URL
+ */
+export async function presignUrl({
+  method,
+  host,
+  path,
+  region,
+  service = 's3',
+  accessKeyId,
+  secretAccessKey,
+  expiresIn,
+  headers = {},
+  date = new Date()
+}) {
+  const amzDate = toAmzDate(date);
+  const shortDate = amzDate.slice(0, 8);
+  const scope = `${shortDate}/${region}/${service}/aws4_request`;
+
+  const allHeaders = { host, ...headers };
+  const headerNames = Object.keys(allHeaders).map((n) => n.toLowerCase()).sort();
+  const signedHeaders = headerNames.join(';');
+  const canonicalHeaders = headerNames
+    .map((name) => {
+      const value = Object.entries(allHeaders).find(([k]) => k.toLowerCase() === name)[1];
+      return `${name}:${String(value).trim()}\n`;
+    })
+    .join('');
+
+  const queryParams = {
+    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+    'X-Amz-Credential': `${accessKeyId}/${scope}`,
+    'X-Amz-Date': amzDate,
+    'X-Amz-Expires': String(expiresIn),
+    'X-Amz-SignedHeaders': signedHeaders
+  };
+  const canonicalQuery = Object.entries(queryParams)
+    .map(([name, value]) => [rfc3986Encode(name), rfc3986Encode(value)])
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([name, value]) => `${name}=${value}`)
+    .join('&');
+
+  const canonicalPath = canonicalizePath(path);
+  const canonicalRequest = [
+    method,
+    canonicalPath,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    'UNSIGNED-PAYLOAD'
+  ].join('\n');
+
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    scope,
+    await sha256Hex(canonicalRequest)
+  ].join('\n');
+
+  let signingKey = await hmac(encoder.encode(`AWS4${secretAccessKey}`), shortDate);
+  signingKey = await hmac(signingKey, region);
+  signingKey = await hmac(signingKey, service);
+  signingKey = await hmac(signingKey, 'aws4_request');
+  const signature = bufferToHex(await hmac(signingKey, stringToSign));
+
+  return `https://${host}${canonicalPath}?${canonicalQuery}&X-Amz-Signature=${signature}`;
+}
+
+/**
+ * Mint a pre-signed R2 PUT URL for an image object, with the SHA-256
+ * checksum bound into the signature: the uploader must send
+ * `x-amz-checksum-sha256: <checksumSha256B64>` and R2 will reject any body
+ * that does not match it.
+ */
+export async function presignR2ImagePut(env, key, checksumSha256B64, expiresIn) {
+  return presignUrl({
+    method: 'PUT',
+    host: `${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    path: `/${env.R2_BUCKET}/${key}`,
+    region: 'auto',
+    accessKeyId: env.R2_ACCESS_KEY_ID,
+    secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+    expiresIn,
+    headers: { 'x-amz-checksum-sha256': checksumSha256B64 }
+  });
+}

--- a/r2-presign.test.js
+++ b/r2-presign.test.js
@@ -1,0 +1,72 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { presignUrl, presignR2ImagePut } from './r2-presign.js';
+
+describe('presignUrl', () => {
+  test('reproduces the documented AWS SigV4 query-auth example', async () => {
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+    // GET test.txt from examplebucket, us-east-1, 20130524T000000Z, 86400s
+    const url = await presignUrl({
+      method: 'GET',
+      host: 'examplebucket.s3.amazonaws.com',
+      path: '/test.txt',
+      region: 'us-east-1',
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      expiresIn: 86400,
+      date: new Date('2013-05-24T00:00:00Z')
+    });
+
+    const parsed = new URL(url);
+    assert.equal(parsed.searchParams.get('X-Amz-Algorithm'), 'AWS4-HMAC-SHA256');
+    assert.equal(
+      parsed.searchParams.get('X-Amz-Credential'),
+      'AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request'
+    );
+    assert.equal(parsed.searchParams.get('X-Amz-Date'), '20130524T000000Z');
+    assert.equal(parsed.searchParams.get('X-Amz-SignedHeaders'), 'host');
+    // The known-good signature from the AWS documentation
+    assert.equal(
+      parsed.searchParams.get('X-Amz-Signature'),
+      'aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404'
+    );
+  });
+
+  test('includes extra headers in the signed header list', async () => {
+    const url = await presignUrl({
+      method: 'PUT',
+      host: 'acc.r2.cloudflarestorage.com',
+      path: '/bucket/owner/repo/abc.png',
+      region: 'auto',
+      accessKeyId: 'key',
+      secretAccessKey: 'secret',
+      expiresIn: 900,
+      headers: { 'x-amz-checksum-sha256': 'Zm9v' },
+      date: new Date('2026-01-01T00:00:00Z')
+    });
+    const parsed = new URL(url);
+    assert.equal(parsed.searchParams.get('X-Amz-SignedHeaders'), 'host;x-amz-checksum-sha256');
+    assert.equal(parsed.searchParams.get('X-Amz-Expires'), '900');
+    assert.match(parsed.searchParams.get('X-Amz-Signature'), /^[a-f0-9]{64}$/);
+  });
+});
+
+describe('presignR2ImagePut', () => {
+  test('builds a path-style R2 URL with the checksum signed in', async () => {
+    const env = {
+      R2_ACCOUNT_ID: 'acct123',
+      R2_BUCKET: 'as-a-bot-images',
+      R2_ACCESS_KEY_ID: 'key',
+      R2_SECRET_ACCESS_KEY: 'secret'
+    };
+    const hash = 'a'.repeat(64);
+    const url = await presignR2ImagePut(env, `octo/demo/${hash}.png`, 'checksumB64=', 900);
+    const parsed = new URL(url);
+    assert.equal(parsed.hostname, 'acct123.r2.cloudflarestorage.com');
+    assert.equal(parsed.pathname, `/as-a-bot-images/octo/demo/${hash}.png`);
+    assert.equal(parsed.searchParams.get('X-Amz-SignedHeaders'), 'host;x-amz-checksum-sha256');
+    assert.ok(parsed.searchParams.get('X-Amz-Credential').startsWith('key/'));
+    assert.ok(parsed.searchParams.get('X-Amz-Credential').includes('/auto/s3/aws4_request'));
+  });
+});

--- a/templates/image-upload.yml
+++ b/templates/image-upload.yml
@@ -1,23 +1,17 @@
+# NOTE: kept in sync with workflow-template.js (the copy the app auto-installs).
 # Image upload broker for `gh image` (ai-aligned-gh).
 #
-# Copy this file to .github/workflows/image-upload.yml in any repository that
-# should support `gh image <file>`. See docs/image-upload-design.md in
-# https://github.com/ai-ecoverse/as-a-bot for the full design.
-#
-# Required Actions secrets (repo- or org-level):
-#   R2_ACCOUNT_ID         Cloudflare account ID
-#   R2_ACCESS_KEY_ID      R2 API token key (object write on the bucket)
-#   R2_SECRET_ACCESS_KEY  R2 API token secret
-# Optional Actions variables:
-#   R2_BUCKET             Bucket name (default: as-a-bot-images)
-#   AS_A_BOT_URL          Worker base URL (default: https://as-bot-worker.minivelos.workers.dev)
+# Installed automatically by the as-a-bot GitHub App
+# (https://github.com/ai-ecoverse/as-a-bot). No secrets required: the
+# workflow only proves repository identity to the as-a-bot worker via
+# GitHub OIDC; the worker mints the pre-signed upload URL itself.
 #
 # Only users with write access can dispatch this workflow — that is the
 # entire authorization model: minting an upload URL requires the same
 # permission as pushing code.
 
 name: Image Upload
-run-name: "Pre-sign image upload ${{ inputs.hash }}.${{ inputs.ext }}"
+run-name: "Request image upload URL ${{ inputs.hash }}.${{ inputs.ext }}"
 
 on:
   workflow_dispatch:
@@ -32,123 +26,35 @@ on:
         type: string
 
 permissions:
-  id-token: write   # OIDC token authenticates the offer to the as-a-bot worker
+  id-token: write   # OIDC token authenticates this repo to the as-a-bot worker
   contents: read
 
 jobs:
-  presign:
+  request-upload-url:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
-
-      - name: Pre-sign upload URL and register it with the worker
+      - name: Request pre-signed upload URL from as-a-bot
         env:
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ vars.R2_BUCKET || 'as-a-bot-images' }}
           AS_A_BOT_URL: ${{ vars.AS_A_BOT_URL || 'https://as-bot-worker.minivelos.workers.dev' }}
           INPUT_HASH: ${{ inputs.hash }}
           INPUT_EXT: ${{ inputs.ext }}
         run: |
-          node << 'SCRIPT'
-          const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
-          const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+          set -euo pipefail
 
-          const ALLOWED_EXT = ["png", "jpg", "jpeg", "gif", "webp", "svg", "avif", "mp4", "mov", "webm"];
-          const OIDC_AUDIENCE = "as-a-bot-images";
-          const EXPIRES_IN = 900; // seconds
+          echo "$INPUT_HASH" | grep -qE '^[a-f0-9]{64}$' || { echo "Invalid hash input"; exit 1; }
+          echo "$INPUT_EXT" | grep -qE '^(png|jpg|jpeg|gif|webp|svg|avif|mp4|mov|webm)$' || { echo "Invalid ext input"; exit 1; }
 
-          async function main() {
-            const hash = (process.env.INPUT_HASH || "").toLowerCase();
-            const ext = (process.env.INPUT_EXT || "").toLowerCase();
+          OIDC_TOKEN=$(curl -sSf \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=as-a-bot-images" | jq -r .value)
 
-            if (!/^[a-f0-9]{64}$/.test(hash)) {
-              throw new Error("Invalid hash input (expected 64 hex chars)");
-            }
-            if (!ALLOWED_EXT.includes(ext)) {
-              throw new Error(`Invalid ext input (allowed: ${ALLOWED_EXT.join(", ")})`);
-            }
-            for (const name of ["R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"]) {
-              if (!process.env[name]) {
-                throw new Error(`Missing required secret: ${name}`);
-              }
-            }
+          # The worker responds with only the serve URL — the pre-signed
+          # upload URL stays out of the (publicly readable) run logs and is
+          # delivered to the gh image client via the worker's status endpoint.
+          RESPONSE=$(curl -sSf -X POST "$AS_A_BOT_URL/image-upload/offer" \
+            -H "Authorization: Bearer $OIDC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"hash\":\"$INPUT_HASH\",\"ext\":\"$INPUT_EXT\"}")
 
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-            const key = `${owner}/${repo}/${hash}.${ext}`;
-            // Binding the checksum into the signature means this URL can ONLY
-            // upload content whose SHA-256 matches the requested hash — a
-            // leaked or stolen URL cannot place different content at this key.
-            const checksumB64 = Buffer.from(hash, "hex").toString("base64");
-
-            const client = new S3Client({
-              region: "auto",
-              endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-              credentials: {
-                accessKeyId: process.env.R2_ACCESS_KEY_ID,
-                secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
-              },
-              // R2 does not support the SDK's newer implicit CRC checksums
-              requestChecksumCalculation: "WHEN_REQUIRED",
-            });
-
-            const command = new PutObjectCommand({
-              Bucket: process.env.R2_BUCKET,
-              Key: key,
-              ChecksumSHA256: checksumB64,
-            });
-            const uploadUrl = await getSignedUrl(client, command, {
-              expiresIn: EXPIRES_IN,
-              // Keep the checksum as a header the uploader must send (signed),
-              // instead of hoisting it into the query string.
-              unhoistableHeaders: new Set(["x-amz-checksum-sha256"]),
-            });
-
-            // Prove our identity (repository) to the worker via GitHub OIDC
-            const tokenRes = await fetch(
-              `${process.env.ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${encodeURIComponent(OIDC_AUDIENCE)}`,
-              { headers: { Authorization: `Bearer ${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN}` } }
-            );
-            if (!tokenRes.ok) {
-              throw new Error(`Failed to obtain OIDC token (status ${tokenRes.status})`);
-            }
-            const { value: oidcToken } = await tokenRes.json();
-
-            const offerRes = await fetch(`${process.env.AS_A_BOT_URL}/image-upload/offer`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${oidcToken}`,
-              },
-              body: JSON.stringify({
-                owner,
-                repo,
-                hash,
-                ext,
-                upload_url: uploadUrl,
-                upload_headers: { "x-amz-checksum-sha256": checksumB64 },
-                expires_in: EXPIRES_IN,
-              }),
-            });
-            if (!offerRes.ok) {
-              const detail = await offerRes.text();
-              throw new Error(`Worker rejected the offer (status ${offerRes.status}): ${detail}`);
-            }
-            const { serve_url } = await offerRes.json();
-            // Never log uploadUrl — it is a bearer capability until it expires
-            console.log(`Upload offer registered for ${key}`);
-            console.log(`Will be served at: ${serve_url}`);
-          }
-
-          main().catch((err) => {
-            console.error(err.message);
-            process.exit(1);
-          });
-          SCRIPT
+          echo "Upload URL registered. File will be served at:"
+          echo "$RESPONSE" | jq -r .serve_url

--- a/templates/image-upload.yml
+++ b/templates/image-upload.yml
@@ -1,0 +1,154 @@
+# Image upload broker for `gh image` (ai-aligned-gh).
+#
+# Copy this file to .github/workflows/image-upload.yml in any repository that
+# should support `gh image <file>`. See docs/image-upload-design.md in
+# https://github.com/ai-ecoverse/as-a-bot for the full design.
+#
+# Required Actions secrets (repo- or org-level):
+#   R2_ACCOUNT_ID         Cloudflare account ID
+#   R2_ACCESS_KEY_ID      R2 API token key (object write on the bucket)
+#   R2_SECRET_ACCESS_KEY  R2 API token secret
+# Optional Actions variables:
+#   R2_BUCKET             Bucket name (default: as-a-bot-images)
+#   AS_A_BOT_URL          Worker base URL (default: https://as-bot-worker.minivelos.workers.dev)
+#
+# Only users with write access can dispatch this workflow — that is the
+# entire authorization model: minting an upload URL requires the same
+# permission as pushing code.
+
+name: Image Upload
+run-name: "Pre-sign image upload ${{ inputs.hash }}.${{ inputs.ext }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      hash:
+        description: "SHA-256 content hash of the file (64 lowercase hex chars)"
+        required: true
+        type: string
+      ext:
+        description: "File extension (png, jpg, jpeg, gif, webp, svg, avif, mp4, mov, webm)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write   # OIDC token authenticates the offer to the as-a-bot worker
+  contents: read
+
+jobs:
+  presign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
+
+      - name: Pre-sign upload URL and register it with the worker
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || 'as-a-bot-images' }}
+          AS_A_BOT_URL: ${{ vars.AS_A_BOT_URL || 'https://as-bot-worker.minivelos.workers.dev' }}
+          INPUT_HASH: ${{ inputs.hash }}
+          INPUT_EXT: ${{ inputs.ext }}
+        run: |
+          node << 'SCRIPT'
+          const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+          const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+
+          const ALLOWED_EXT = ["png", "jpg", "jpeg", "gif", "webp", "svg", "avif", "mp4", "mov", "webm"];
+          const OIDC_AUDIENCE = "as-a-bot-images";
+          const EXPIRES_IN = 900; // seconds
+
+          async function main() {
+            const hash = (process.env.INPUT_HASH || "").toLowerCase();
+            const ext = (process.env.INPUT_EXT || "").toLowerCase();
+
+            if (!/^[a-f0-9]{64}$/.test(hash)) {
+              throw new Error("Invalid hash input (expected 64 hex chars)");
+            }
+            if (!ALLOWED_EXT.includes(ext)) {
+              throw new Error(`Invalid ext input (allowed: ${ALLOWED_EXT.join(", ")})`);
+            }
+            for (const name of ["R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"]) {
+              if (!process.env[name]) {
+                throw new Error(`Missing required secret: ${name}`);
+              }
+            }
+
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+            const key = `${owner}/${repo}/${hash}.${ext}`;
+            // Binding the checksum into the signature means this URL can ONLY
+            // upload content whose SHA-256 matches the requested hash — a
+            // leaked or stolen URL cannot place different content at this key.
+            const checksumB64 = Buffer.from(hash, "hex").toString("base64");
+
+            const client = new S3Client({
+              region: "auto",
+              endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+              credentials: {
+                accessKeyId: process.env.R2_ACCESS_KEY_ID,
+                secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+              },
+              // R2 does not support the SDK's newer implicit CRC checksums
+              requestChecksumCalculation: "WHEN_REQUIRED",
+            });
+
+            const command = new PutObjectCommand({
+              Bucket: process.env.R2_BUCKET,
+              Key: key,
+              ChecksumSHA256: checksumB64,
+            });
+            const uploadUrl = await getSignedUrl(client, command, {
+              expiresIn: EXPIRES_IN,
+              // Keep the checksum as a header the uploader must send (signed),
+              // instead of hoisting it into the query string.
+              unhoistableHeaders: new Set(["x-amz-checksum-sha256"]),
+            });
+
+            // Prove our identity (repository) to the worker via GitHub OIDC
+            const tokenRes = await fetch(
+              `${process.env.ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${encodeURIComponent(OIDC_AUDIENCE)}`,
+              { headers: { Authorization: `Bearer ${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN}` } }
+            );
+            if (!tokenRes.ok) {
+              throw new Error(`Failed to obtain OIDC token (status ${tokenRes.status})`);
+            }
+            const { value: oidcToken } = await tokenRes.json();
+
+            const offerRes = await fetch(`${process.env.AS_A_BOT_URL}/image-upload/offer`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${oidcToken}`,
+              },
+              body: JSON.stringify({
+                owner,
+                repo,
+                hash,
+                ext,
+                upload_url: uploadUrl,
+                upload_headers: { "x-amz-checksum-sha256": checksumB64 },
+                expires_in: EXPIRES_IN,
+              }),
+            });
+            if (!offerRes.ok) {
+              const detail = await offerRes.text();
+              throw new Error(`Worker rejected the offer (status ${offerRes.status}): ${detail}`);
+            }
+            const { serve_url } = await offerRes.json();
+            // Never log uploadUrl — it is a bearer capability until it expires
+            console.log(`Upload offer registered for ${key}`);
+            console.log(`Will be served at: ${serve_url}`);
+          }
+
+          main().catch((err) => {
+            console.error(err.message);
+            process.exit(1);
+          });
+          SCRIPT

--- a/worker.js
+++ b/worker.js
@@ -229,13 +229,110 @@ async function handleUserTokenPoll(request, env, body) {
     
     // Calculate expiration
     const expiresAt = new Date(Date.now() + (data.expires_in || 28800) * 1000).toISOString();
-    
+    const refreshTokenExpiresAt = data.refresh_token_expires_in
+      ? new Date(Date.now() + data.refresh_token_expires_in * 1000).toISOString()
+      : null;
+
     return new Response(JSON.stringify({
       access_token: finalToken,
       token_type: data.token_type || 'bearer',
       expires_at: expiresAt,
+      expires_in: data.expires_in || 28800,
+      refresh_token: data.refresh_token || null,
+      refresh_token_expires_at: refreshTokenExpiresAt,
       scope: data.scope,
       app_attribution: finalToken !== data.access_token // Indicate if we got an installation token
+    }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store'
+      }
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({
+      error: 'server_error',
+      error_description: error.message
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+// Handle /user-token/refresh endpoint
+// GitHub user-to-server tokens expire (8h by default); clients holding the
+// refresh token can renew without redoing the device flow.
+async function handleUserTokenRefresh(request, env, body) {
+  const { refresh_token } = body;
+
+  if (!refresh_token) {
+    return new Response(JSON.stringify({
+      error: 'refresh_token is required'
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const clientId = env.GITHUB_CLIENT_ID;
+  const clientSecret = env.GITHUB_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    return new Response(JSON.stringify({
+      error: 'server_error',
+      error_description: 'Token refresh not configured on this server'
+    }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const url = 'https://github.com/login/oauth/access_token';
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'refresh_token',
+    refresh_token
+  });
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    });
+
+    const data = await response.json();
+
+    if (data.error) {
+      return new Response(JSON.stringify({
+        error: data.error,
+        error_description: data.error_description
+      }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const expiresAt = new Date(Date.now() + (data.expires_in || 28800) * 1000).toISOString();
+    const refreshTokenExpiresAt = data.refresh_token_expires_in
+      ? new Date(Date.now() + data.refresh_token_expires_in * 1000).toISOString()
+      : null;
+
+    return new Response(JSON.stringify({
+      access_token: data.access_token,
+      token_type: data.token_type || 'bearer',
+      expires_at: expiresAt,
+      expires_in: data.expires_in || 28800,
+      // GitHub rotates the refresh token on each use; return the new one.
+      refresh_token: data.refresh_token || null,
+      refresh_token_expires_at: refreshTokenExpiresAt,
+      scope: data.scope
     }), {
       status: 200,
       headers: {
@@ -298,6 +395,7 @@ export default {
         endpoints: {
           '/user-token/start': 'Start device flow (POST)',
           '/user-token/poll': 'Poll device flow (POST)',
+          '/user-token/refresh': 'Refresh an expired user token (POST)',
           '/auth/start': 'Start web flow (POST)',
           '/auth/callback': 'OAuth callback (GET)',
           '/auth/poll': 'Poll web flow (POST)',
@@ -354,6 +452,10 @@ export default {
         
         case '/user-token/poll':
           response = await handleUserTokenPoll(request, env, body);
+          break;
+
+        case '/user-token/refresh':
+          response = await handleUserTokenRefresh(request, env, body);
           break;
 
         case '/image-upload/offer':

--- a/worker.js
+++ b/worker.js
@@ -257,16 +257,29 @@ async function handleUserTokenPoll(request, env, body) {
 // Import web flow handlers
 import webFlow from './worker-web.js';
 
+// Import image upload handlers (gh image)
+import { handleImageOffer, handleImageStatus, handleImageServe } from './image-upload.js';
+
 // Main request handler
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
-    
+
     // Route web flow endpoints to web flow handler
     if (url.pathname.startsWith('/auth/')) {
       return webFlow.fetch(request, env, ctx);
     }
-    
+
+    // Serve uploaded images/videos from R2 (gh image)
+    if (url.pathname.startsWith('/i/') && (request.method === 'GET' || request.method === 'HEAD')) {
+      return handleImageServe(request, env);
+    }
+
+    // Poll endpoint for pending image uploads (gh image)
+    if (url.pathname === '/image-upload/status' && request.method === 'GET') {
+      return handleImageStatus(request, env);
+    }
+
     // Allow GET for health check
     if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/health')) {
       return new Response(JSON.stringify({
@@ -278,7 +291,10 @@ export default {
           '/user-token/poll': 'Poll device flow (POST)',
           '/auth/start': 'Start web flow (POST)',
           '/auth/callback': 'OAuth callback (GET)',
-          '/auth/poll': 'Poll web flow (POST)'
+          '/auth/poll': 'Poll web flow (POST)',
+          '/image-upload/offer': 'Register pre-signed upload URL from workflow (POST, OIDC)',
+          '/image-upload/status': 'Poll for pre-signed upload URL (GET)',
+          '/i/{owner}/{repo}/{hash}.{ext}': 'Serve uploaded image/video (GET)'
         }
       }), {
         status: 200,
@@ -329,7 +345,11 @@ export default {
         case '/user-token/poll':
           response = await handleUserTokenPoll(request, env, body);
           break;
-        
+
+        case '/image-upload/offer':
+          response = await handleImageOffer(request, env, body);
+          break;
+
         default:
           response = new Response(JSON.stringify({
             error: 'Not found'

--- a/worker.js
+++ b/worker.js
@@ -260,6 +260,9 @@ import webFlow from './worker-web.js';
 // Import image upload handlers (gh image)
 import { handleImageOffer, handleImageStatus, handleImageServe } from './image-upload.js';
 
+// Import GitHub App webhook handler (auto-installs the image-upload workflow)
+import { handleGitHubWebhook } from './app-install.js';
+
 // Main request handler
 export default {
   async fetch(request, env, ctx) {
@@ -280,6 +283,12 @@ export default {
       return handleImageStatus(request, env);
     }
 
+    // GitHub App webhook (handled before generic body parsing because the
+    // signature check needs the raw request body)
+    if (url.pathname === '/webhook' && request.method === 'POST') {
+      return handleGitHubWebhook(request, env, ctx);
+    }
+
     // Allow GET for health check
     if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/health')) {
       return new Response(JSON.stringify({
@@ -292,9 +301,10 @@ export default {
           '/auth/start': 'Start web flow (POST)',
           '/auth/callback': 'OAuth callback (GET)',
           '/auth/poll': 'Poll web flow (POST)',
-          '/image-upload/offer': 'Register pre-signed upload URL from workflow (POST, OIDC)',
+          '/image-upload/offer': 'Request pre-signed upload URL from workflow (POST, OIDC)',
           '/image-upload/status': 'Poll for pre-signed upload URL (GET)',
-          '/i/{owner}/{repo}/{hash}.{ext}': 'Serve uploaded image/video (GET)'
+          '/i/{owner}/{repo}/{hash}.{ext}': 'Serve uploaded image/video (GET)',
+          '/webhook': 'GitHub App webhook: auto-install image-upload workflow (POST)'
         }
       }), {
         status: 200,

--- a/workflow-template.js
+++ b/workflow-template.js
@@ -1,0 +1,75 @@
+/**
+ * The image-upload workflow that the as-a-bot app commits to repositories
+ * automatically when it is installed (see app-install.js).
+ *
+ * The workflow is a thin authorization relay: GitHub only lets users with
+ * write access dispatch it, and its OIDC token proves to the worker which
+ * repository is asking. The worker mints the pre-signed R2 PUT URL itself,
+ * so the repository needs NO secrets.
+ *
+ * templates/image-upload.yml mirrors this content for manual installs —
+ * keep the two in sync.
+ */
+
+export const IMAGE_UPLOAD_WORKFLOW_PATH = '.github/workflows/image-upload.yml';
+
+export const IMAGE_UPLOAD_WORKFLOW_YAML = `# Image upload broker for \`gh image\` (ai-aligned-gh).
+#
+# Installed automatically by the as-a-bot GitHub App
+# (https://github.com/ai-ecoverse/as-a-bot). No secrets required: the
+# workflow only proves repository identity to the as-a-bot worker via
+# GitHub OIDC; the worker mints the pre-signed upload URL itself.
+#
+# Only users with write access can dispatch this workflow — that is the
+# entire authorization model: minting an upload URL requires the same
+# permission as pushing code.
+
+name: Image Upload
+run-name: "Request image upload URL \${{ inputs.hash }}.\${{ inputs.ext }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      hash:
+        description: "SHA-256 content hash of the file (64 lowercase hex chars)"
+        required: true
+        type: string
+      ext:
+        description: "File extension (png, jpg, jpeg, gif, webp, svg, avif, mp4, mov, webm)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write   # OIDC token authenticates this repo to the as-a-bot worker
+  contents: read
+
+jobs:
+  request-upload-url:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request pre-signed upload URL from as-a-bot
+        env:
+          AS_A_BOT_URL: \${{ vars.AS_A_BOT_URL || 'https://as-bot-worker.minivelos.workers.dev' }}
+          INPUT_HASH: \${{ inputs.hash }}
+          INPUT_EXT: \${{ inputs.ext }}
+        run: |
+          set -euo pipefail
+
+          echo "\$INPUT_HASH" | grep -qE '^[a-f0-9]{64}$' || { echo "Invalid hash input"; exit 1; }
+          echo "\$INPUT_EXT" | grep -qE '^(png|jpg|jpeg|gif|webp|svg|avif|mp4|mov|webm)$' || { echo "Invalid ext input"; exit 1; }
+
+          OIDC_TOKEN=\$(curl -sSf \\
+            -H "Authorization: Bearer \$ACTIONS_ID_TOKEN_REQUEST_TOKEN" \\
+            "\$ACTIONS_ID_TOKEN_REQUEST_URL&audience=as-a-bot-images" | jq -r .value)
+
+          # The worker responds with only the serve URL — the pre-signed
+          # upload URL stays out of the (publicly readable) run logs and is
+          # delivered to the gh image client via the worker's status endpoint.
+          RESPONSE=\$(curl -sSf -X POST "\$AS_A_BOT_URL/image-upload/offer" \\
+            -H "Authorization: Bearer \$OIDC_TOKEN" \\
+            -H "Content-Type: application/json" \\
+            -d "{\\"hash\\":\\"\$INPUT_HASH\\",\\"ext\\":\\"\$INPUT_EXT\\"}")
+
+          echo "Upload URL registered. File will be served at:"
+          echo "\$RESPONSE" | jq -r .serve_url
+`;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,6 +39,7 @@ R2_BUCKET = "as-a-bot-images"
 # GITHUB_APP_PRIVATE_KEY - PEM format private key
 # GITHUB_APP_ID - Numeric App ID
 # GITHUB_CLIENT_ID - App Client ID
+# GITHUB_CLIENT_SECRET - App Client Secret (web flow + token refresh)
 # GITHUB_WEBHOOK_SECRET - App webhook secret (for /webhook)
 # R2_ACCESS_KEY_ID - R2 S3 credential for pre-signing upload URLs
 # R2_SECRET_ACCESS_KEY - R2 S3 credential for pre-signing upload URLs

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,9 +32,14 @@ bucket_name = "as-a-bot-images"
 GITHUB_API = "https://api.github.com"
 ALLOWED_ORIGINS = ""
 IMAGE_OIDC_AUDIENCE = "as-a-bot-images"
+R2_ACCOUNT_ID = "155ec15a52a18a14801e04b019da5e5a"
+R2_BUCKET = "as-a-bot-images"
 
 # Secrets (configure with wrangler secret put)
 # GITHUB_APP_PRIVATE_KEY - PEM format private key
 # GITHUB_APP_ID - Numeric App ID
 # GITHUB_CLIENT_ID - App Client ID
+# GITHUB_WEBHOOK_SECRET - App webhook secret (for /webhook)
+# R2_ACCESS_KEY_ID - R2 S3 credential for pre-signing upload URLs
+# R2_SECRET_ACCESS_KEY - R2 S3 credential for pre-signing upload URLs
 # CLOUDFLARE_TOKEN - For GitHub Actions deployment

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,10 +16,22 @@ id = "4d16c1ca5973424990ae00ab7f5c6bf7"
 binding = "AUTH_STATES"
 id = "6fac9e3755f74be0b56d33da9d0942d9"
 
+# KV Namespace for pending image upload offers (gh image)
+[[kv_namespaces]]
+binding = "IMAGE_OFFERS"
+id = "5587c4066bef45e9b58440e90afcc738"
+
+# R2 bucket for uploaded images/videos (gh image)
+# Create before first deploy: wrangler r2 bucket create as-a-bot-images
+[[r2_buckets]]
+binding = "IMAGES"
+bucket_name = "as-a-bot-images"
+
 # Environment variables (non-sensitive)
 [vars]
 GITHUB_API = "https://api.github.com"
 ALLOWED_ORIGINS = ""
+IMAGE_OIDC_AUDIENCE = "as-a-bot-images"
 
 # Secrets (configure with wrangler secret put)
 # GITHUB_APP_PRIVATE_KEY - PEM format private key


### PR DESCRIPTION
## Problem

`gh` on its own can't attach images to a PR or issue ([cli/cli#12960](https://github.com/cli/cli/issues/12960)) — a real limitation for coding agents. The existing workaround ([gh-image](https://github.com/drogers0/gh-image)) drives a remote-controlled browser. This PR implements a different approach: content-addressed uploads to an R2 bucket, brokered by this worker and gated by a maintainer-only GitHub Actions workflow (mirroring the mcpecrets pattern of Worker-for-compute, Actions-for-trust-boundary).

Companion PR: `gh image` client in ai-ecoverse/ai-aligned-gh#64.

## How it works

1. **Installing the as-a-bot app is the only per-repo setup.** `POST /webhook` handles installation events (HMAC-verified) and commits the secret-free `image-upload.yml` workflow to each repository automatically (never overwriting an existing one).
2. `gh image <file>` computes the file's SHA-256 and dispatches that workflow with `hash` + `ext`. **GitHub only lets users with write access dispatch workflows** — that's the entire authorization model.
3. The workflow is a thin relay: it POSTs `{hash, ext}` to `/image-upload/offer` with a GitHub **OIDC token**. The worker derives `owner/repo` exclusively from the token's `repository` claim (coordinates can't be spoofed) and **mints the pre-signed R2 PUT URL itself** (`r2-presign.js` — dependency-free SigV4, verified against the AWS documentation test vector) with **`x-amz-checksum-sha256` as a signed header**. R2 credentials live only as worker secrets; repositories hold none. The upload URL is never returned to the workflow (run logs are publicly readable) — only via the status endpoint.
4. `gh image` polls `GET /image-upload/status`, uploads to the pre-signed URL, and embeds the serve URL.
5. `GET /i/{owner}/{repo}/{hash}.{ext}` serves from R2 with immutable caching (capped at remaining lifetime), requiring the stored SHA-256 checksum to match the content-addressed key.
6. **Uploads expire after 90 days**: the serve path refuses and deletes expired objects (410), the status endpoint stops reporting them as uploaded, and re-running `gh image` on the same file renews the identical URL. Pair with an R2 lifecycle rule for storage reclamation.

Full design + trust model in **docs/image-upload-design.md**.

## Verified against real R2

The presigner was exercised end-to-end against the live `as-a-bot-images` bucket: a presigned PUT minted by `r2-presign.js` uploaded correct content (200) and **rejected different content with the same URL (400)** — the checksum binding holds in practice, not just in tests. (Test object deleted afterwards.)

## Changes

- `image-upload.js` — offer/status/serve handlers, 90-day TTL enforcement
- `r2-presign.js` — SigV4 query presigner (reproduces AWS's documented reference signature)
- `github-oidc.js` — GitHub Actions OIDC verification (JWKS, RS256 via WebCrypto)
- `app-install.js` — webhook signature verification + workflow auto-install via installation tokens
- `workflow-template.js` / `templates/image-upload.yml` — the secret-free workflow (JS module is what the app commits; the template mirrors it for manual installs)
- `.github/workflows/deploy.yml` — CI deployment: on push to main, run tests, sync worker secrets from Actions secrets, `wrangler deploy`
- `worker.js` — route wiring; **ports the deployed-but-never-committed `/user-token/refresh` endpoint and refresh-token poll fields back into the repo** (production had drifted ahead; without this, the first CI deploy would have removed them)
- `wrangler.toml` — `IMAGE_OFFERS` KV binding (created: `5587c4066bef45e9b58440e90afcc738`), `IMAGES` R2 binding (bucket created), `R2_ACCOUNT_ID`/`R2_BUCKET` vars
- `docs/image-upload-design.md`, README, 39 tests (`npm test`: 41 pass total)

## Deployment status

Deployment is CI-driven on merge; everything is in place:

- ✅ Actions secrets set: `CLOUDFLARE_TOKEN`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `GH_WEBHOOK_SECRET` (Actions forbids the `GITHUB_` prefix; deploy syncs it to the `GITHUB_WEBHOOK_SECRET` worker secret)
- ✅ R2 bucket `as-a-bot-images` + KV namespace provisioned; presigner validated end-to-end against live R2
- ✅ GitHub App webhook configured with the same secret
- ⬜ Merge → CI deploys
- ⬜ Optional storage reclamation: `wrangler r2 bucket lifecycle add as-a-bot-images --name expire-uploads --expire-days 90` (needs an R2-admin token; the worker enforces the 90-day TTL at serve time regardless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE