### PR TITLE
Serve images from agentbin.net (wildcard domain) + homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ delivered to GitHub Apps automatically.
 | `GITHUB_API` | GitHub API URL (default: https://api.github.com) | No |
 | `IMAGE_OIDC_AUDIENCE` | OIDC audience for image upload offers (default: as-a-bot-images) | No |
 | `R2_ACCOUNT_ID` / `R2_BUCKET` | R2 coordinates for image uploads | For gh image |
+| `IMAGE_SERVE_DOMAIN` | Wildcard domain for embeddable serve URLs (`repo--owner.<domain>/<hash>.<ext>`); needs a matching `*.<domain>` route | No |
 | `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 credentials (secret; pre-signing only) | For gh image |
 | `GITHUB_WEBHOOK_SECRET` | App webhook secret (secret; for /webhook) | For auto-install |
 

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -243,11 +243,17 @@ The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) along
 with the `R2_ACCOUNT_ID` / `R2_BUCKET` / `IMAGE_OIDC_AUDIENCE` vars.
 
 For embeddable hostname-based URLs, put a zone on the Cloudflare account and
-set in `wrangler.toml`:
+configure `wrangler.toml` — note that `routes` is a **top-level** key while
+`IMAGE_SERVE_DOMAIN` lives under `[vars]`:
 
 ```toml
+# top level (next to name/main)
+routes = [
+  { pattern = "*.img.example.com/*", zone_name = "example.com" }
+]
+
+[vars]
 IMAGE_SERVE_DOMAIN = "img.example.com"
-routes = [ { pattern = "*.img.example.com/*", zone_name = "example.com" } ]
 ```
 
 (A `*.img.example.com` wildcard DNS record proxied through Cloudflare makes

--- a/docs/image-upload-design.md
+++ b/docs/image-upload-design.md
@@ -115,8 +115,16 @@ R2 bucket: <owner>/<repo>/<hash>.png ◄──── 9. GET /i/<owner>/<repo>/<h
 7. `gh image` PUTs the file to `upload_url` with the returned headers
    (`x-amz-checksum-sha256: <base64 hash>` + `Content-Type`). R2 rejects the
    upload if the body doesn't match the signed checksum.
-8. `gh image` verifies `HEAD <serve_url>` succeeds and prints the serve URL:
-   `https://<worker>/i/<owner>/<repo>/<hash>.<ext>`.
+8. `gh image` verifies `HEAD <serve_url>` succeeds and prints the serve URL.
+   With a wildcard serve domain configured (`IMAGE_SERVE_DOMAIN`), that is
+   `https://<repo>--<owner>.<domain>/<hash>.<ext>` — GitHub's Camo image
+   proxy is reluctant about `*.workers.dev` hosts, and hostname-based URLs
+   are cleaner to embed. Path-based
+   `https://<worker>/i/<owner>/<repo>/<hash>.<ext>` always works as a
+   fallback (and is what repos with non-hostname-safe names — dots,
+   underscores — get). Owner names cannot contain `--` (GitHub rule), so
+   the last `--` in the host label is always the separator; keys are
+   lowercased since GitHub names are case-insensitively unique.
 
 ## Worker API
 
@@ -126,6 +134,7 @@ R2 bucket: <owner>/<repo>/<hash>.png ◄──── 9. GET /i/<owner>/<repo>/<h
 | `/image-upload/offer` | POST | GitHub Actions OIDC (aud `as-a-bot-images`) | Workflow requests a pre-signed upload URL |
 | `/image-upload/status` | GET | none | Client polls for the upload URL / upload state |
 | `/i/{owner}/{repo}/{hash}.{ext}` | GET, HEAD | none | Serve the stored object (immutable caching) |
+| `https://{repo}--{owner}.<IMAGE_SERVE_DOMAIN>/{hash}.{ext}` | GET, HEAD | none | Hostname-based serving on the wildcard domain (same objects) |
 
 Offer payload (owner/repo come from the OIDC token, never the body):
 
@@ -232,6 +241,18 @@ lands as `GITHUB_WEBHOOK_SECRET` — Actions secret names may not start with
 `CLOUDFLARE_TOKEN` Actions secret).
 The bindings are declared in `wrangler.toml` (`IMAGES`, `IMAGE_OFFERS`) along
 with the `R2_ACCOUNT_ID` / `R2_BUCKET` / `IMAGE_OIDC_AUDIENCE` vars.
+
+For embeddable hostname-based URLs, put a zone on the Cloudflare account and
+set in `wrangler.toml`:
+
+```toml
+IMAGE_SERVE_DOMAIN = "img.example.com"
+routes = [ { pattern = "*.img.example.com/*", zone_name = "example.com" } ]
+```
+
+(A `*.img.example.com` wildcard DNS record proxied through Cloudflare makes
+the route resolve; the worker then serves
+`https://<repo>--<owner>.img.example.com/<hash>.<ext>`.)
 
 ## Limitations / future work
 

--- a/homepage.js
+++ b/homepage.js
@@ -1,0 +1,121 @@
+/**
+ * Homepage for the image serve domain (agentbin.net).
+ *
+ * Served on the apex and www hosts of IMAGE_SERVE_DOMAIN; every other
+ * subdomain under the serve domain is content-addressed image serving
+ * (repo--owner.<domain>/<hash>.<ext>).
+ */
+
+export function isHomepageHost(hostname, env) {
+  const domain = (env.IMAGE_SERVE_DOMAIN || '').toLowerCase();
+  if (!domain) {
+    return false;
+  }
+  const host = (hostname || '').toLowerCase();
+  return host === domain || host === `www.${domain}`;
+}
+
+const HOMEPAGE_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>agentbin — image uploads for coding agents</title>
+  <meta name="description" content="Content-addressed image and video hosting for gh image: attach screenshots and recordings to GitHub PRs and issues from the command line.">
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      background: #0d1117;
+      color: #c9d1d9;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 2rem 1rem;
+      line-height: 1.6;
+    }
+    main {
+      max-width: 40rem;
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 12px;
+      padding: 2.5rem;
+    }
+    h1 { font-size: 1.7rem; margin-bottom: .4rem; }
+    h1 .tld { color: #8b949e; font-weight: 400; }
+    .tagline { color: #8b949e; margin-bottom: 1.6rem; }
+    p { margin-bottom: 1rem; }
+    pre {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: .9rem 1.1rem;
+      overflow-x: auto;
+      font-size: .85rem;
+      margin-bottom: 1.6rem;
+    }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .links { display: flex; flex-wrap: wrap; gap: .6rem; margin-bottom: 1.6rem; }
+    .links a {
+      display: inline-block;
+      padding: .45rem .9rem;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      color: #58a6ff;
+      text-decoration: none;
+      font-size: .9rem;
+    }
+    .links a:hover { background: #21262d; border-color: #8b949e; }
+    .fine { color: #8b949e; font-size: .8rem; }
+    .fine code { color: #c9d1d9; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>agentbin<span class="tld">.net</span></h1>
+    <p class="tagline">Content-addressed image &amp; video hosting for coding agents.</p>
+    <p>
+      <code>gh</code> can't attach images to pull requests or issues — a real
+      limitation for coding agents that want to show a screenshot or screen
+      recording. <code>gh image</code> fixes that:
+    </p>
+    <pre><code>$ gh pr comment 42 --body "Before/after: $(gh image --markdown shot.png)"</code></pre>
+    <p>
+      Uploads are gated on repository write access via a GitHub Actions
+      workflow the <strong>as-a-bot</strong> app installs automatically, bound
+      to their SHA-256 content hash end to end, and served immutably from
+      <code>&lt;repo&gt;--&lt;owner&gt;.agentbin.net</code> for 90 days.
+    </p>
+    <div class="links">
+      <a href="https://github.com/ai-ecoverse/as-a-bot">GitHub repo</a>
+      <a href="https://github.com/apps/as-a-bot">Install the app</a>
+      <a href="https://github.com/ai-ecoverse">ai-ecoverse org</a>
+    </div>
+    <p class="fine">
+      Serve URLs look like
+      <code>https://&lt;repo&gt;--&lt;owner&gt;.agentbin.net/&lt;sha256&gt;.&lt;ext&gt;</code>
+      — the same file always gets the same URL, and a URL can never change
+      content. Part of the AI Ecoverse.
+    </p>
+  </main>
+</body>
+</html>
+`;
+
+// Handle GET/HEAD on the apex or www host of the serve domain
+export function handleHomepage(request) {
+  const { pathname } = new URL(request.url);
+  if (pathname !== '/' && pathname !== '/index.html') {
+    return new Response('Not found', { status: 404 });
+  }
+  const headers = {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'public, max-age=3600'
+  };
+  if (request.method === 'HEAD') {
+    return new Response(null, { status: 200, headers });
+  }
+  return new Response(HOMEPAGE_HTML, { status: 200, headers });
+}

--- a/homepage.test.js
+++ b/homepage.test.js
@@ -1,0 +1,40 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { handleHomepage, isHomepageHost } from './homepage.js';
+
+const ENV = { IMAGE_SERVE_DOMAIN: 'agentbin.net' };
+
+describe('isHomepageHost', () => {
+  test('matches the apex and www hosts only', () => {
+    assert.equal(isHomepageHost('agentbin.net', ENV), true);
+    assert.equal(isHomepageHost('www.agentbin.net', ENV), true);
+    assert.equal(isHomepageHost('WWW.AGENTBIN.NET', ENV), true);
+    assert.equal(isHomepageHost('repo--owner.agentbin.net', ENV), false);
+    assert.equal(isHomepageHost('agentbin.net', {}), false);
+  });
+});
+
+describe('handleHomepage', () => {
+  test('serves the homepage with the three links', async () => {
+    const response = handleHomepage(new Request('https://www.agentbin.net/'));
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('Content-Type'), /text\/html/);
+    const html = await response.text();
+    assert.match(html, /github\.com\/ai-ecoverse\/as-a-bot/);
+    assert.match(html, /github\.com\/apps\/as-a-bot/);
+    assert.match(html, /"https:\/\/github\.com\/ai-ecoverse"/);
+    assert.match(html, /gh image/);
+  });
+
+  test('404s other paths', () => {
+    const response = handleHomepage(new Request('https://www.agentbin.net/anything'));
+    assert.equal(response.status, 404);
+  });
+
+  test('answers HEAD without a body', async () => {
+    const response = handleHomepage(new Request('https://agentbin.net/', { method: 'HEAD' }));
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '');
+  });
+});

--- a/image-upload.js
+++ b/image-upload.js
@@ -81,12 +81,52 @@ function validateHashExt(hash, ext) {
   return null;
 }
 
+// Keys are lowercased: GitHub owner/repo names are case-insensitively
+// unique, and the wildcard serve hostnames (DNS) are always lowercase.
 function objectKey(owner, repo, hash, ext) {
-  return `${owner}/${repo}/${hash}.${ext}`;
+  return `${owner.toLowerCase()}/${repo.toLowerCase()}/${hash}.${ext}`;
 }
 
-function serveUrlFor(request, key) {
-  return `${new URL(request.url).origin}/i/${key}`;
+// A hostname label must be [a-z0-9-], no leading/trailing hyphen, <= 63
+// chars. GitHub owner names always qualify; repo names may not (dots,
+// underscores) — those repos fall back to path-based serve URLs.
+const HOST_LABEL_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Parse `repo--owner.<domain>` into coordinates. Owner names cannot
+ * contain consecutive hyphens (GitHub rule), so the LAST `--` in the
+ * label is always the separator even when the repo name contains `--`.
+ * Returns { owner, repo } or null.
+ */
+export function coordinatesFromHost(hostname, env) {
+  const domain = (env.IMAGE_SERVE_DOMAIN || '').toLowerCase();
+  if (!domain) {
+    return null;
+  }
+  const host = (hostname || '').toLowerCase();
+  if (!host.endsWith(`.${domain}`)) {
+    return null;
+  }
+  const label = host.slice(0, -(domain.length + 1));
+  if (!label || label.includes('.')) {
+    return null;
+  }
+  const separator = label.lastIndexOf('--');
+  if (separator <= 0 || separator + 2 >= label.length) {
+    return null;
+  }
+  return { owner: label.slice(separator + 2), repo: label.slice(0, separator) };
+}
+
+function serveUrlFor(request, env, owner, repo, hash, ext) {
+  const domain = (env.IMAGE_SERVE_DOMAIN || '').toLowerCase();
+  if (domain) {
+    const label = `${repo.toLowerCase()}--${owner.toLowerCase()}`;
+    if (HOST_LABEL_PATTERN.test(label)) {
+      return `https://${label}.${domain}/${hash}.${ext}`;
+    }
+  }
+  return `${new URL(request.url).origin}/i/${objectKey(owner, repo, hash, ext)}`;
 }
 
 function hexToBase64(hex) {
@@ -184,7 +224,7 @@ export async function handleImageOffer(request, env, body) {
   // Only the serve URL goes back to the workflow: the workflow's run logs
   // are readable by anyone with repo read access, so the pre-signed URL
   // must never appear there. The client fetches it from /image-upload/status.
-  return jsonResponse({ status: 'ready', serve_url: serveUrlFor(request, key) }, 201);
+  return jsonResponse({ status: 'ready', serve_url: serveUrlFor(request, env, owner, repo, hash, ext) }, 201);
 }
 
 function bufferToHex(buffer) {
@@ -226,7 +266,7 @@ export async function handleImageStatus(request, env) {
   }
 
   const key = objectKey(owner, repo, hash, ext);
-  const serveUrl = serveUrlFor(request, key);
+  const serveUrl = serveUrlFor(request, env, owner, repo, hash, ext);
 
   // Already uploaded (content-addressed, so this is also the dedupe path).
   // Only counts if the object would actually be served — same checksum and
@@ -273,17 +313,31 @@ function serveHeaders(object, ext) {
   return headers;
 }
 
-// Handle GET/HEAD /i/{owner}/{repo}/{hash}.{ext}
+// Handle GET/HEAD /i/{owner}/{repo}/{hash}.{ext} on the worker host, and
+// GET/HEAD /{hash}.{ext} on the wildcard serve domain (repo--owner.<domain>)
 export async function handleImageServe(request, env) {
   if (!env.IMAGES) {
     return jsonResponse({ error: 'Image serving not configured (IMAGES R2 binding missing)' }, 503);
   }
 
-  const match = new URL(request.url).pathname.match(SERVE_PATH_PATTERN);
-  if (!match) {
-    return jsonResponse({ error: 'not_found' }, 404);
+  const url = new URL(request.url);
+  let owner, repo, hash, ext;
+
+  const hostCoordinates = coordinatesFromHost(url.hostname, env);
+  if (hostCoordinates) {
+    const match = url.pathname.match(/^\/([a-f0-9]{64})\.([a-z0-9]+)$/);
+    if (!match) {
+      return jsonResponse({ error: 'not_found' }, 404);
+    }
+    ({ owner, repo } = hostCoordinates);
+    [, hash, ext] = match;
+  } else {
+    const match = url.pathname.match(SERVE_PATH_PATTERN);
+    if (!match) {
+      return jsonResponse({ error: 'not_found' }, 404);
+    }
+    [, owner, repo, hash, ext] = match;
   }
-  const [, owner, repo, hash, ext] = match;
   if (!Object.prototype.hasOwnProperty.call(IMAGE_CONTENT_TYPES, ext)) {
     return jsonResponse({ error: 'not_found' }, 404);
   }

--- a/image-upload.js
+++ b/image-upload.js
@@ -93,6 +93,20 @@ function objectKey(owner, repo, hash, ext) {
 const HOST_LABEL_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
 
 /**
+ * True when the request hostname belongs to the configured serve domain
+ * (the apex or any subdomain). Used to fence the serve domain off from
+ * the API: hosts under it only ever serve images.
+ */
+export function isImageServeHost(hostname, env) {
+  const domain = (env.IMAGE_SERVE_DOMAIN || '').toLowerCase();
+  if (!domain) {
+    return false;
+  }
+  const host = (hostname || '').toLowerCase();
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+/**
  * Parse `repo--owner.<domain>` into coordinates. Owner names cannot
  * contain consecutive hyphens (GitHub rule), so the LAST `--` in the
  * label is always the separator even when the repo name contains `--`.
@@ -108,7 +122,9 @@ export function coordinatesFromHost(hostname, env) {
     return null;
   }
   const label = host.slice(0, -(domain.length + 1));
-  if (!label || label.includes('.')) {
+  // The label must be a single, well-formed DNS hostname label — this is
+  // derived from the Host header, so validate before splitting.
+  if (!label || label.includes('.') || !HOST_LABEL_PATTERN.test(label)) {
     return null;
   }
   const separator = label.lastIndexOf('--');

--- a/image-upload.test.js
+++ b/image-upload.test.js
@@ -7,6 +7,7 @@ import {
   handleImageServe,
   validateOfferPayload,
   coordinatesFromHost,
+  isImageServeHost,
   IMAGE_CONTENT_TYPES,
   UPLOAD_TTL_S
 } from './image-upload.js';
@@ -348,6 +349,23 @@ describe('wildcard serve domain', () => {
     assert.equal(coordinatesFromHost('no-separator.img.example.com', DOMAIN_ENV), null);
     assert.equal(coordinatesFromHost('a.b.img.example.com', DOMAIN_ENV), null);
     assert.equal(coordinatesFromHost('repo--owner.img.example.com', {}), null);
+  });
+
+  test('coordinatesFromHost rejects malformed hostname labels', () => {
+    assert.equal(coordinatesFromHost('repo_x--owner.img.example.com', DOMAIN_ENV), null);
+    assert.equal(coordinatesFromHost('-repo--owner.img.example.com', DOMAIN_ENV), null);
+    assert.equal(coordinatesFromHost('repo--owner-.img.example.com', DOMAIN_ENV), null);
+    const tooLong = `${'a'.repeat(70)}--owner.img.example.com`;
+    assert.equal(coordinatesFromHost(tooLong, DOMAIN_ENV), null);
+  });
+
+  test('isImageServeHost fences the whole serve domain', () => {
+    assert.equal(isImageServeHost('repo--owner.img.example.com', DOMAIN_ENV), true);
+    assert.equal(isImageServeHost('anything.img.example.com', DOMAIN_ENV), true);
+    assert.equal(isImageServeHost('img.example.com', DOMAIN_ENV), true);
+    assert.equal(isImageServeHost('worker.example.dev', DOMAIN_ENV), false);
+    assert.equal(isImageServeHost('evil-img.example.com', DOMAIN_ENV), false);
+    assert.equal(isImageServeHost('repo--owner.img.example.com', {}), false);
   });
 
   test('status returns wildcard serve URLs when the domain is configured', async () => {

--- a/image-upload.test.js
+++ b/image-upload.test.js
@@ -6,6 +6,7 @@ import {
   handleImageStatus,
   handleImageServe,
   validateOfferPayload,
+  coordinatesFromHost,
   IMAGE_CONTENT_TYPES,
   UPLOAD_TTL_S
 } from './image-upload.js';
@@ -323,6 +324,86 @@ describe('handleImageServe', () => {
   test('HEAD 404s on missing objects', async () => {
     const response = await handleImageServe(new Request(serveUrl, { method: 'HEAD' }), { IMAGES: makeR2() });
     assert.equal(response.status, 404);
+  });
+});
+
+describe('wildcard serve domain', () => {
+  const DOMAIN_ENV = { IMAGE_SERVE_DOMAIN: 'img.example.com' };
+
+  test('coordinatesFromHost parses repo--owner labels', () => {
+    assert.deepEqual(
+      coordinatesFromHost('ai-aligned-gh--ai-ecoverse.img.example.com', DOMAIN_ENV),
+      { owner: 'ai-ecoverse', repo: 'ai-aligned-gh' }
+    );
+    // The LAST -- separates: repos may contain --, owners cannot
+    assert.deepEqual(
+      coordinatesFromHost('my--repo--octo.img.example.com', DOMAIN_ENV),
+      { owner: 'octo', repo: 'my--repo' }
+    );
+  });
+
+  test('coordinatesFromHost rejects non-matching hosts', () => {
+    assert.equal(coordinatesFromHost('worker.example.dev', DOMAIN_ENV), null);
+    assert.equal(coordinatesFromHost('img.example.com', DOMAIN_ENV), null);
+    assert.equal(coordinatesFromHost('no-separator.img.example.com', DOMAIN_ENV), null);
+    assert.equal(coordinatesFromHost('a.b.img.example.com', DOMAIN_ENV), null);
+    assert.equal(coordinatesFromHost('repo--owner.img.example.com', {}), null);
+  });
+
+  test('status returns wildcard serve URLs when the domain is configured', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: { size: 3, body: 'abc', checksums: { sha256: hexToBuffer(HASH) } }
+    });
+    const request = new Request(`https://worker.example/image-upload/status?owner=Octo&repo=Demo&hash=${HASH}&ext=png`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: r2, ...DOMAIN_ENV });
+    const body = await response.json();
+    assert.equal(body.status, 'uploaded');
+    assert.equal(body.serve_url, `https://demo--octo.img.example.com/${HASH}.png`);
+  });
+
+  test('falls back to path URLs for repos that are not hostname-safe', async () => {
+    const r2 = makeR2({
+      [`octo/my.dotted.repo/${HASH}.png`]: { size: 3, body: 'abc', checksums: { sha256: hexToBuffer(HASH) } }
+    });
+    const request = new Request(`https://worker.example/image-upload/status?owner=octo&repo=my.dotted.repo&hash=${HASH}&ext=png`);
+    const response = await handleImageStatus(request, { IMAGE_OFFERS: makeKV(), IMAGES: r2, ...DOMAIN_ENV });
+    const body = await response.json();
+    assert.equal(body.serve_url, `https://worker.example/i/octo/my.dotted.repo/${HASH}.png`);
+  });
+
+  test('serves objects addressed by wildcard hostname', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        body: 'imagebytes',
+        size: 10,
+        checksums: { sha256: hexToBuffer(HASH) }
+      }
+    });
+    const request = new Request(`https://demo--octo.img.example.com/${HASH}.png`);
+    const response = await handleImageServe(request, { IMAGES: r2, ...DOMAIN_ENV });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('Content-Type'), 'image/png');
+    assert.equal(await response.text(), 'imagebytes');
+  });
+
+  test('404s wildcard-host paths that are not a bare hash', async () => {
+    const r2 = makeR2({});
+    const request = new Request('https://demo--octo.img.example.com/health');
+    const response = await handleImageServe(request, { IMAGES: r2, ...DOMAIN_ENV });
+    assert.equal(response.status, 404);
+  });
+
+  test('path-based serving still works when the domain is configured', async () => {
+    const r2 = makeR2({
+      [`octo/demo/${HASH}.png`]: {
+        body: 'imagebytes',
+        size: 10,
+        checksums: { sha256: hexToBuffer(HASH) }
+      }
+    });
+    const request = new Request(`https://worker.example/i/Octo/Demo/${HASH}.png`);
+    const response = await handleImageServe(request, { IMAGES: r2, ...DOMAIN_ENV });
+    assert.equal(response.status, 200);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test worker.test.js image-upload.test.js r2-presign.test.js app-install.test.js"
+    "test": "node --test worker.test.js image-upload.test.js r2-presign.test.js app-install.test.js homepage.test.js"
   },
   "keywords": [
     "github",

--- a/worker.js
+++ b/worker.js
@@ -355,7 +355,7 @@ async function handleUserTokenRefresh(request, env, body) {
 import webFlow from './worker-web.js';
 
 // Import image upload handlers (gh image)
-import { handleImageOffer, handleImageStatus, handleImageServe, coordinatesFromHost } from './image-upload.js';
+import { handleImageOffer, handleImageStatus, handleImageServe, isImageServeHost } from './image-upload.js';
 
 // Import GitHub App webhook handler (auto-installs the image-upload workflow)
 import { handleGitHubWebhook } from './app-install.js';
@@ -365,16 +365,28 @@ export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
+    // The wildcard serve domain is fenced off from the API: hosts under
+    // IMAGE_SERVE_DOMAIN only ever serve images
+    // (repo--owner.<IMAGE_SERVE_DOMAIN>/<hash>.<ext>) — everything else
+    // there is 404, and API routes stay on the worker host.
+    if (isImageServeHost(url.hostname, env)) {
+      if (request.method === 'GET' || request.method === 'HEAD') {
+        return handleImageServe(request, env);
+      }
+      return new Response(JSON.stringify({ error: 'not_found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     // Route web flow endpoints to web flow handler
     if (url.pathname.startsWith('/auth/')) {
       return webFlow.fetch(request, env, ctx);
     }
 
-    // Serve uploaded images/videos from R2 (gh image) — path-based on the
-    // worker host, or hostname-based on the wildcard serve domain
-    // (repo--owner.<IMAGE_SERVE_DOMAIN>/<hash>.<ext>)
-    if ((request.method === 'GET' || request.method === 'HEAD') &&
-        (url.pathname.startsWith('/i/') || coordinatesFromHost(url.hostname, env))) {
+    // Serve uploaded images/videos from R2 (gh image), path-based on the
+    // worker host
+    if (url.pathname.startsWith('/i/') && (request.method === 'GET' || request.method === 'HEAD')) {
       return handleImageServe(request, env);
     }
 

--- a/worker.js
+++ b/worker.js
@@ -355,7 +355,7 @@ async function handleUserTokenRefresh(request, env, body) {
 import webFlow from './worker-web.js';
 
 // Import image upload handlers (gh image)
-import { handleImageOffer, handleImageStatus, handleImageServe } from './image-upload.js';
+import { handleImageOffer, handleImageStatus, handleImageServe, coordinatesFromHost } from './image-upload.js';
 
 // Import GitHub App webhook handler (auto-installs the image-upload workflow)
 import { handleGitHubWebhook } from './app-install.js';
@@ -370,8 +370,11 @@ export default {
       return webFlow.fetch(request, env, ctx);
     }
 
-    // Serve uploaded images/videos from R2 (gh image)
-    if (url.pathname.startsWith('/i/') && (request.method === 'GET' || request.method === 'HEAD')) {
+    // Serve uploaded images/videos from R2 (gh image) — path-based on the
+    // worker host, or hostname-based on the wildcard serve domain
+    // (repo--owner.<IMAGE_SERVE_DOMAIN>/<hash>.<ext>)
+    if ((request.method === 'GET' || request.method === 'HEAD') &&
+        (url.pathname.startsWith('/i/') || coordinatesFromHost(url.hostname, env))) {
       return handleImageServe(request, env);
     }
 

--- a/worker.js
+++ b/worker.js
@@ -360,17 +360,24 @@ import { handleImageOffer, handleImageStatus, handleImageServe, isImageServeHost
 // Import GitHub App webhook handler (auto-installs the image-upload workflow)
 import { handleGitHubWebhook } from './app-install.js';
 
+// Import homepage for the serve domain (apex + www)
+import { handleHomepage, isHomepageHost } from './homepage.js';
+
 // Main request handler
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
-    // The wildcard serve domain is fenced off from the API: hosts under
-    // IMAGE_SERVE_DOMAIN only ever serve images
+    // The wildcard serve domain is fenced off from the API: the apex and
+    // www hosts serve the homepage, every other host under
+    // IMAGE_SERVE_DOMAIN only serves images
     // (repo--owner.<IMAGE_SERVE_DOMAIN>/<hash>.<ext>) — everything else
     // there is 404, and API routes stay on the worker host.
     if (isImageServeHost(url.hostname, env)) {
       if (request.method === 'GET' || request.method === 'HEAD') {
+        if (isHomepageHost(url.hostname, env)) {
+          return handleHomepage(request);
+        }
         return handleImageServe(request, env);
       }
       return new Response(JSON.stringify({ error: 'not_found' }), {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,12 @@ main = "worker.js"
 compatibility_date = "2024-01-01"
 account_id = "155ec15a52a18a14801e04b019da5e5a"
 
+# Wildcard route for embeddable image serve URLs (gh image):
+#   https://<repo>--<owner>.agentbin.net/<hash>.<ext>
+routes = [
+  { pattern = "*.agentbin.net/*", zone_name = "agentbin.net" }
+]
+
 [env.production]
 name = "as-bot-worker"
 
@@ -37,10 +43,8 @@ R2_BUCKET = "as-a-bot-images"
 # Wildcard serve domain for embeddable image URLs:
 #   https://<repo>--<owner>.<IMAGE_SERVE_DOMAIN>/<hash>.<ext>
 # Empty = disabled (path-based /i/ URLs on the worker host only).
-# To enable: set the domain here and add a wildcard route for a zone on
-# this account, e.g.
-#   routes = [ { pattern = "*.img.example.com/*", zone_name = "example.com" } ]
-IMAGE_SERVE_DOMAIN = ""
+# Requires the matching wildcard route above.
+IMAGE_SERVE_DOMAIN = "agentbin.net"
 
 # Secrets (configure with wrangler secret put)
 # GITHUB_APP_PRIVATE_KEY - PEM format private key

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,8 +5,10 @@ account_id = "155ec15a52a18a14801e04b019da5e5a"
 
 # Wildcard route for embeddable image serve URLs (gh image):
 #   https://<repo>--<owner>.agentbin.net/<hash>.<ext>
+# The apex route serves the homepage (also on www, via the wildcard).
 routes = [
-  { pattern = "*.agentbin.net/*", zone_name = "agentbin.net" }
+  { pattern = "*.agentbin.net/*", zone_name = "agentbin.net" },
+  { pattern = "agentbin.net/*", zone_name = "agentbin.net" }
 ]
 
 [env.production]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,6 +34,13 @@ ALLOWED_ORIGINS = ""
 IMAGE_OIDC_AUDIENCE = "as-a-bot-images"
 R2_ACCOUNT_ID = "155ec15a52a18a14801e04b019da5e5a"
 R2_BUCKET = "as-a-bot-images"
+# Wildcard serve domain for embeddable image URLs:
+#   https://<repo>--<owner>.<IMAGE_SERVE_DOMAIN>/<hash>.<ext>
+# Empty = disabled (path-based /i/ URLs on the worker host only).
+# To enable: set the domain here and add a wildcard route for a zone on
+# this account, e.g.
+#   routes = [ { pattern = "*.img.example.com/*", zone_name = "example.com" } ]
+IMAGE_SERVE_DOMAIN = ""
 
 # Secrets (configure with wrangler secret put)
 # GITHUB_APP_PRIVATE_KEY - PEM format private key


### PR DESCRIPTION
Follow-up to #15/#18. Serve `gh image` uploads from the **agentbin.net** wildcard domain so the URLs embed cleanly in GitHub Markdown, plus a homepage:

```
https://<repo>--<owner>.agentbin.net/<hash>.<ext>
```

## Why

The current serve URLs live on `*.workers.dev`, which GitHub's Camo image proxy is reluctant to inline (and the URLs are ugly). Hostname-based addressing on a real domain fixes both — same Edge-Delivery-style `repo--owner` pattern.

## Design points

- **Separator is unambiguous**: GitHub owner names cannot contain consecutive hyphens, so the *last* `--` in the host label always splits `repo--owner`, even for repo names containing `--` (covered by tests).
- **Keys are lowercased** everywhere now: GitHub names are case-insensitively unique and DNS hostnames force lowercase. (The one existing object is already all-lowercase.)
- **The serve domain is fenced off from the API** (review feedback): hosts under `IMAGE_SERVE_DOMAIN` only serve images — POST/API paths there are 404, and API routes stay on the worker host. Host labels are validated against DNS label rules before parsing.
- **Homepage**: `agentbin.net` and `www.agentbin.net` serve a small landing page linking the [GitHub repo](https://github.com/ai-ecoverse/as-a-bot), the [app install page](https://github.com/apps/as-a-bot), and the [ai-ecoverse org](https://github.com/ai-ecoverse).
- **Graceful fallback**: repos whose names aren't hostname-safe (dots, underscores, >63-char labels) keep path-based `/i/{owner}/{repo}/{hash}.{ext}` URLs, which remain supported on the worker host regardless of the setting.
- The offer/status endpoints return whichever serve URL form is active, and the ai-aligned-gh client (ai-ecoverse/ai-aligned-gh#64) prefers the worker-provided `serve_url`, so the switch needs no client change.

## Config

`wrangler.toml` now declares `IMAGE_SERVE_DOMAIN = "agentbin.net"` plus the `*.agentbin.net/*` and apex routes (routes are declared in config so deploys keep them attached). The proxied wildcard DNS record already resolves. The design doc's enablement example was fixed to show `routes` (top-level) and `IMAGE_SERVE_DOMAIN` (`[vars]`) separately (review feedback).

54 tests pass; `wrangler deploy --dry-run` bundles cleanly. **On merge, CI deploys and `https://ai-aligned-gh--ai-ecoverse.agentbin.net/50d9d31a….png` goes live** (same object as today's `/i/` URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE