### PR TITLE
Hotfix: re-enable the workers.dev subdomain alongside custom routes

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,12 @@ main = "worker.js"
 compatibility_date = "2024-01-01"
 account_id = "155ec15a52a18a14801e04b019da5e5a"
 
+# Keep the workers.dev subdomain alive alongside the custom routes -
+# every existing client (ai-aligned-gh auth flows, gh image polling, the
+# GitHub App webhook) targets as-bot-worker.minivelos.workers.dev, and
+# declaring routes disables workers.dev by default.
+workers_dev = true
+
 # Wildcard route for embeddable image serve URLs (gh image):
 #   https://<repo>--<owner>.agentbin.net/<hash>.<ext>
 # The apex route serves the homepage (also on www, via the wildcard).


### PR DESCRIPTION
**Urgent one-liner.** The #20 deploy declared `routes` in `wrangler.toml`, and Cloudflare **disables the workers.dev subdomain by default when routes exist** — so `as-bot-worker.minivelos.workers.dev` currently 404s everything (`error code: 1042`): device-flow auth for the wrapper, `gh image` status polling, and the GitHub App webhook all target that hostname and are broken right now. The agentbin.net routes themselves work fine.

`workers_dev = true` keeps both hostnames served. Merge → CI deploys → workers.dev is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE)_