### PR TITLE
Homepage: add ai-aligned-gh link and install instructions

### DIFF
--- a/homepage.js
+++ b/homepage.js
@@ -45,6 +45,11 @@ const HOMEPAGE_HTML = `<!DOCTYPE html>
     }
     h1 { font-size: 1.7rem; margin-bottom: .4rem; }
     h1 .tld { color: #8b949e; font-weight: 400; }
+    h2 { font-size: 1.1rem; margin-bottom: .8rem; }
+    ol.steps { margin: 0 0 1.6rem 1.2rem; }
+    ol.steps li { margin-bottom: .8rem; }
+    ol.steps pre { margin: .5rem 0 0 0; }
+    a { color: #58a6ff; }
     .tagline { color: #8b949e; margin-bottom: 1.6rem; }
     p { margin-bottom: 1rem; }
     pre {
@@ -88,8 +93,26 @@ const HOMEPAGE_HTML = `<!DOCTYPE html>
       to their SHA-256 content hash end to end, and served immutably from
       <code>&lt;repo&gt;--&lt;owner&gt;.agentbin.net</code> for 90 days.
     </p>
+    <h2>Get started</h2>
+    <ol class="steps">
+      <li>
+        Install the <a href="https://github.com/ai-ecoverse/ai-aligned-gh">ai-aligned-gh</a>
+        wrapper (it provides the <code>gh image</code> command):
+        <pre><code>curl -fsSL https://raw.githubusercontent.com/ai-ecoverse/ai-aligned-gh/main/install.sh | sh</code></pre>
+      </li>
+      <li>
+        Install the <a href="https://github.com/apps/as-a-bot">as-a-bot GitHub App</a>
+        on your repositories — it commits the upload workflow automatically;
+        no secrets or other configuration needed.
+      </li>
+      <li>
+        Upload away:
+        <pre><code>gh image screenshot.png</code></pre>
+      </li>
+    </ol>
     <div class="links">
-      <a href="https://github.com/ai-ecoverse/as-a-bot">GitHub repo</a>
+      <a href="https://github.com/ai-ecoverse/as-a-bot">as-a-bot</a>
+      <a href="https://github.com/ai-ecoverse/ai-aligned-gh">ai-aligned-gh</a>
       <a href="https://github.com/apps/as-a-bot">Install the app</a>
       <a href="https://github.com/ai-ecoverse">ai-ecoverse org</a>
     </div>

--- a/homepage.test.js
+++ b/homepage.test.js
@@ -16,15 +16,17 @@ describe('isHomepageHost', () => {
 });
 
 describe('handleHomepage', () => {
-  test('serves the homepage with the three links', async () => {
+  test('serves the homepage with links and install instructions', async () => {
     const response = handleHomepage(new Request('https://www.agentbin.net/'));
     assert.equal(response.status, 200);
     assert.match(response.headers.get('Content-Type'), /text\/html/);
     const html = await response.text();
     assert.match(html, /github\.com\/ai-ecoverse\/as-a-bot/);
+    assert.match(html, /github\.com\/ai-ecoverse\/ai-aligned-gh/);
     assert.match(html, /github\.com\/apps\/as-a-bot/);
     assert.match(html, /"https:\/\/github\.com\/ai-ecoverse"/);
-    assert.match(html, /gh image/);
+    assert.match(html, /install\.sh \| sh/);
+    assert.match(html, /gh image screenshot\.png/);
   });
 
   test('404s other paths', () => {


### PR DESCRIPTION
The homepage pitched `gh image` without saying how to get it. Add a three-step "Get started" section — install the [ai-aligned-gh](https://github.com/ai-ecoverse/ai-aligned-gh) wrapper (`install.sh` one-liner), install the [as-a-bot app](https://github.com/apps/as-a-bot), run `gh image` — and add ai-aligned-gh to the link row alongside as-a-bot, the app, and the [ai-ecoverse org](https://github.com/ai-ecoverse).

54 tests pass. On merge, CI deploys and https://www.agentbin.net/ updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE)_