### PR TITLE
Decouple homepage test from install command formatting

### DIFF
--- a/homepage.test.js
+++ b/homepage.test.js
@@ -25,7 +25,7 @@ describe('handleHomepage', () => {
     assert.match(html, /github\.com\/ai-ecoverse\/ai-aligned-gh/);
     assert.match(html, /github\.com\/apps\/as-a-bot/);
     assert.match(html, /"https:\/\/github\.com\/ai-ecoverse"/);
-    assert.match(html, /install\.sh \| sh/);
+    assert.match(html, /raw\.githubusercontent\.com\/ai-ecoverse\/ai-aligned-gh\/main\/install\.sh/);
     assert.match(html, /gh image screenshot\.png/);
   });
 

--- a/homepage.test.js
+++ b/homepage.test.js
@@ -25,7 +25,7 @@ describe('handleHomepage', () => {
     assert.match(html, /github\.com\/ai-ecoverse\/ai-aligned-gh/);
     assert.match(html, /github\.com\/apps\/as-a-bot/);
     assert.match(html, /"https:\/\/github\.com\/ai-ecoverse"/);
-    assert.match(html, /raw\.githubusercontent\.com\/ai-ecoverse\/ai-aligned-gh\/main\/install\.sh/);
+    assert.match(html, /raw\.githubusercontent\.com\/ai-ecoverse\/ai-aligned-gh\/[^/]+\/install\.sh/);
     assert.match(html, /gh image screenshot\.png/);
   });
 


### PR DESCRIPTION
One-line test cleanup that missed the #22 merge by seconds: assert on the install script URL instead of the `install.sh | sh` pipe syntax, so the test survives wording changes to the install instructions (Copilot review feedback on #22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE)_