### PR TITLE
Fix homepage layout on mobile

### DIFF
--- a/homepage.js
+++ b/homepage.js
@@ -60,13 +60,13 @@ const HOMEPAGE_HTML = `<!DOCTYPE html>
       border-radius: 6px;
       padding: .9rem 1.1rem;
       overflow-x: auto;
+      max-width: 100%;
       font-size: .85rem;
       margin-bottom: 1.6rem;
     }
     code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     /* long inline URLs must wrap, not widen the page */
     p code, li code, .fine code { overflow-wrap: anywhere; }
-    pre { max-width: 100%; }
     @media (max-width: 480px) {
       body { padding: .75rem .5rem; }
       main { padding: 1.5rem 1.1rem; }

--- a/homepage.js
+++ b/homepage.js
@@ -30,13 +30,15 @@ const HOMEPAGE_HTML = `<!DOCTYPE html>
       background: #0d1117;
       color: #c9d1d9;
       display: flex;
-      justify-content: center;
-      align-items: center;
       min-height: 100vh;
       padding: 2rem 1rem;
       line-height: 1.6;
     }
     main {
+      /* margin auto centers both axes without the align-items:center
+         flexbox trap that clips overflowing content on small screens */
+      margin: auto;
+      width: 100%;
       max-width: 40rem;
       background: #161b22;
       border: 1px solid #30363d;
@@ -62,6 +64,14 @@ const HOMEPAGE_HTML = `<!DOCTYPE html>
       margin-bottom: 1.6rem;
     }
     code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    /* long inline URLs must wrap, not widen the page */
+    p code, li code, .fine code { overflow-wrap: anywhere; }
+    pre { max-width: 100%; }
+    @media (max-width: 480px) {
+      body { padding: .75rem .5rem; }
+      main { padding: 1.5rem 1.1rem; }
+      h1 { font-size: 1.4rem; }
+    }
     .links { display: flex; flex-wrap: wrap; gap: .6rem; margin-bottom: 1.6rem; }
     .links a {
       display: inline-block;


### PR DESCRIPTION
Fixes the "cursed on mobile" homepage ([reported on X](https://x.com/steveruizok)). Root cause: the card was vertically centered with flexbox `align-items: center`, which **unscrollably clips the top of overflowing content** — a classic flexbox trap that phones hit as soon as the Get-started section made the card taller than the viewport.

- Center the card with `margin: auto` on the flex child instead (same centering for short viewports, scrollable when tall)
- `overflow-wrap: anywhere` on long inline code URLs so they wrap instead of widening the page
- Tighter padding + smaller heading under 480px

Missed the #23 merge by seconds (same one-commit race as before), hence its own PR. 54 tests pass; merge deploys it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE)_